### PR TITLE
Add PostHog analytics and allow --mode static

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ Add to your MCP client config:
 ```bash
 npm install
 
-# Static mode (all 229 tools)
+# Dynamic mode (default — progressive discovery, 4 meta-tools, ~1,300 tokens)
 node bin/mcp-server.js start --api-key "$APIDECK_API_KEY" --consumer-id "$APIDECK_CONSUMER_ID" --app-id "$APIDECK_APP_ID"
 
-# Dynamic mode (progressive discovery — 4 meta-tools, ~1,300 tokens)
-node bin/mcp-server.js start --api-key "$APIDECK_API_KEY" --consumer-id "$APIDECK_CONSUMER_ID" --app-id "$APIDECK_APP_ID" --mode dynamic
+# Static mode (all 229 tools)
+node bin/mcp-server.js start --api-key "$APIDECK_API_KEY" --consumer-id "$APIDECK_CONSUMER_ID" --app-id "$APIDECK_APP_ID" --mode static
 
 # Read-only tools only
 node bin/mcp-server.js start --api-key "$APIDECK_API_KEY" --consumer-id "$APIDECK_CONSUMER_ID" --app-id "$APIDECK_APP_ID" --scope read
@@ -157,8 +157,8 @@ agent = Agent("anthropic:claude-sonnet-4-5", mcp_servers=[
 
 | Mode | Tools exposed | Initial tokens | Best for |
 |---|---|---|---|
-| `static` (default) | All 229 tools | ~25-40K | Focused agents doing specific operations |
-| `dynamic` | 4 meta-tools: `list_tools`, `describe_tool_input`, `execute_tool`, `list_scopes` | ~1,300 | General-purpose agents, token-sensitive contexts |
+| `dynamic` (default) | 4 meta-tools: `list_tools`, `describe_tool_input`, `execute_tool`, `list_scopes` | ~1,300 | General-purpose agents, token-sensitive contexts |
+| `static` | All 229 tools | ~25-40K | Focused agents doing specific operations |
 
 In dynamic mode, agents discover tools progressively:
 

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -1,11 +1,13 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { createAnalytics } from "../src/mcp-server/analytics.js";
 import { createMCPServer } from "../src/mcp-server/server.js";
 import { createConsoleLogger } from "../src/mcp-server/console-logger.js";
 import { ApideckMcpCore } from "../src/core.js";
 
 const logger = createConsoleLogger("info");
+const analytics = createAnalytics(process.env["POSTHOG_API_KEY"], logger);
 
 export const config = {
   maxDuration: 60,
@@ -69,6 +71,7 @@ export default async function handler(req: IncomingMessage & { body?: any }, res
 
   const { server: mcpServer } = createMCPServer({
     logger,
+    analytics,
     dynamic: true,
     getSDK,
   });
@@ -81,4 +84,5 @@ export default async function handler(req: IncomingMessage & { body?: any }, res
 
   await mcpServer.connect(transport as Transport);
   await transport.handleRequest(req, res, req.body);
+  await analytics.flush();
 }

--- a/src/cloudflare-worker/cloudflare-worker.ts
+++ b/src/cloudflare-worker/cloudflare-worker.ts
@@ -7,6 +7,7 @@ import { McpAgent } from "agents/mcp";
 import type { Env } from "../../worker-configuration.js";
 import { ApideckMcpCore } from "../core.js";
 import { landingPage } from "../landing-page.js";
+import { createAnalytics } from "../mcp-server/analytics.js";
 import { createConsoleLogger } from "../mcp-server/console-logger.js";
 import { createMCPServer } from "../mcp-server/server.js";
 
@@ -18,8 +19,12 @@ export class AtApideckMcpMCP extends McpAgent<Env, State, Props> {
   server!: McpServer;
 
   async init() {
+    const logger = createConsoleLogger("debug");
+    const analytics = createAnalytics(this.env.POSTHOG_API_KEY, logger);
+
     const { server } = createMCPServer({
-      logger: createConsoleLogger("debug"),
+      logger,
+      analytics,
       getSDK: () => this.getSDK(),
     });
 

--- a/src/mcp-server/analytics.ts
+++ b/src/mcp-server/analytics.ts
@@ -1,0 +1,83 @@
+import { ConsoleLogger } from "./console-logger.js";
+
+export interface AnalyticsEvent {
+  distinctId: string;
+  event: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface Analytics {
+  capture(event: AnalyticsEvent): void;
+  flush(): Promise<void>;
+}
+
+const POSTHOG_API_HOST = "https://eu.i.posthog.com";
+const BATCH_SIZE = 20;
+const FLUSH_INTERVAL_MS = 10_000;
+
+export function createAnalytics(
+  apiKey: string | undefined,
+  logger: ConsoleLogger,
+): Analytics {
+  if (!apiKey) {
+    return { capture() {}, async flush() {} };
+  }
+
+  const queue: AnalyticsEvent[] = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  async function flush() {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (queue.length === 0) return;
+
+    const batch = queue.splice(0);
+    const payload = {
+      api_key: apiKey,
+      batch: batch.map((e) => ({
+        event: e.event,
+        distinct_id: e.distinctId,
+        properties: {
+          ...e.properties,
+          $lib: "apideck-mcp",
+        },
+        timestamp: new Date().toISOString(),
+      })),
+    };
+
+    try {
+      const res = await fetch(`${POSTHOG_API_HOST}/batch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        logger.warning("PostHog batch failed", { status: res.status });
+      }
+    } catch (err) {
+      logger.warning("PostHog batch error", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  function scheduleFlush() {
+    if (!timer) {
+      timer = setTimeout(() => flush(), FLUSH_INTERVAL_MS);
+    }
+  }
+
+  return {
+    capture(event: AnalyticsEvent) {
+      queue.push(event);
+      if (queue.length >= BATCH_SIZE) {
+        flush();
+      } else {
+        scheduleFlush();
+      }
+    },
+    flush,
+  };
+}

--- a/src/mcp-server/cli/serve/command.ts
+++ b/src/mcp-server/cli/serve/command.ts
@@ -41,7 +41,7 @@ export const serveCommand = buildCommand({
         kind: "enum",
         brief:
           "Server mode (dynamic is default; use --mode static for all tools)",
-        values: ["dynamic"],
+        values: ["dynamic", "static"],
         optional: true,
         default: "dynamic",
       },

--- a/src/mcp-server/cli/serve/impl.ts
+++ b/src/mcp-server/cli/serve/impl.ts
@@ -6,6 +6,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import express from "express";
 import { LocalContext } from "../../cli.js";
+import { createAnalytics } from "../../analytics.js";
 import {
   ConsoleLoggerLevel,
   createConsoleLogger,
@@ -34,6 +35,7 @@ export async function main(this: LocalContext, flags: ServeCommandFlags) {
 
 async function startStreamableHTTP(cliFlags: ServeCommandFlags) {
   const logger = createConsoleLogger(cliFlags["log-level"]);
+  const analytics = createAnalytics(process.env["POSTHOG_API_KEY"], logger);
   const app = express();
 
   // Enable CORS for cross-origin requests
@@ -64,6 +66,7 @@ async function startStreamableHTTP(cliFlags: ServeCommandFlags) {
 
     const { server: mcpServer } = createMCPServer({
       logger,
+      analytics,
       allowedTools: cliFlags.tool,
       dynamic: cliFlags.mode === "dynamic",
       annotationFilter: buildAnnotationFilter(cliFlags["tool-annotations"]),
@@ -95,8 +98,9 @@ async function startStreamableHTTP(cliFlags: ServeCommandFlags) {
     logger.info("MCP Streamable HTTP server started", { host });
   });
 
-  const shutdown = () => {
+  const shutdown = async () => {
     logger.info("Shutting down HTTP server");
+    await analytics.flush();
 
     const timer = setTimeout(() => {
       logger.info("Forcing shutdown");

--- a/src/mcp-server/cli/start/command.ts
+++ b/src/mcp-server/cli/start/command.ts
@@ -41,7 +41,7 @@ export const startCommand = buildCommand({
         kind: "enum",
         brief:
           "Server mode (dynamic is default; use --mode static for all tools)",
-        values: ["dynamic"],
+        values: ["dynamic", "static"],
         optional: true,
         default: "dynamic",
       },

--- a/src/mcp-server/flags.ts
+++ b/src/mcp-server/flags.ts
@@ -11,7 +11,7 @@ import { MCPScope } from "./scopes.js";
  */
 export interface MCPServerFlags {
   readonly tool?: string[];
-  readonly mode?: "dynamic" | undefined;
+  readonly mode?: "dynamic" | "static" | undefined;
   readonly "tool-annotations"?: string[] | undefined;
   readonly scope?: MCPScope[];
   readonly "api-key"?: string | undefined;

--- a/src/mcp-server/server.ts
+++ b/src/mcp-server/server.ts
@@ -12,6 +12,7 @@ import {
   createRegisterResourceTemplate,
 } from "./resources.js";
 import { MCPScope } from "./scopes.js";
+import type { Analytics } from "./analytics.js";
 import {
   createRegisterTool,
   MCPToolAnnotationFilter,
@@ -259,6 +260,7 @@ export function createMCPServer(deps: {
   consumerId?: SDKOptions["consumerId"] | undefined;
   appId?: SDKOptions["appId"] | undefined;
   serverIdx?: SDKOptions["serverIdx"] | undefined;
+  analytics?: Analytics | undefined;
 }) {
   const server = new McpServer({
     name: "ApideckMcp",
@@ -292,6 +294,7 @@ export function createMCPServer(deps: {
     allowedTools,
     deps.dynamic,
     deps.annotationFilter,
+    deps.analytics,
   );
   const resource = createRegisterResource(
     deps.logger,
@@ -540,7 +543,7 @@ export function createMCPServer(deps: {
   tool(tool$vaultLogsList);
 
   if (deps.dynamic) {
-    registerDynamicTools(deps.logger, server, getClient, toolMap, scopes);
+    registerDynamicTools(deps.logger, server, getClient, toolMap, scopes, deps.analytics);
   }
 
   return { server, tools };

--- a/src/mcp-server/tools.ts
+++ b/src/mcp-server/tools.ts
@@ -17,6 +17,7 @@ import * as z from "zod";
 import { ApideckMcpCore } from "../core.js";
 import { ConsoleLogger } from "./console-logger.js";
 import { MCPServerFlags } from "./flags.js";
+import type { Analytics } from "./analytics.js";
 import { MCPScope, mcpScopes } from "./scopes.js";
 import { valueToBase64 } from "./shared.js";
 
@@ -135,6 +136,7 @@ export function createRegisterTool(
   allowedTools?: Set<string>,
   dynamic?: boolean,
   annotationFilter?: MCPToolAnnotationFilter,
+  analytics?: Analytics,
 ): [
   <A extends ZodRawShapeCompat | undefined>(tool: ToolDefinition<A>) => void,
   Array<{ name: string; description: string }>,
@@ -212,7 +214,19 @@ export function createRegisterTool(
           annotations: tool.annotations,
         },
         async (args, ctx) => {
-          return tool.tool(getSDK(), args, ctx);
+          const start = Date.now();
+          const result = await tool.tool(getSDK(), args, ctx);
+          analytics?.capture({
+            distinctId: "mcp-server",
+            event: "mcp_tool_called",
+            properties: {
+              tool_name: tool.name,
+              is_error: result.isError ?? false,
+              duration_ms: Date.now() - start,
+              mode: "static",
+            },
+          });
+          return result;
         },
       );
     } else {
@@ -223,7 +237,19 @@ export function createRegisterTool(
           annotations: tool.annotations,
         },
         async (ctx) => {
-          return tool.tool(getSDK(), ctx);
+          const start = Date.now();
+          const result = await tool.tool(getSDK(), ctx);
+          analytics?.capture({
+            distinctId: "mcp-server",
+            event: "mcp_tool_called",
+            properties: {
+              tool_name: tool.name,
+              is_error: result.isError ?? false,
+              duration_ms: Date.now() - start,
+              mode: "static",
+            },
+          });
+          return result;
         },
       );
     }
@@ -263,6 +289,7 @@ export function registerDynamicTools(
   getSDK: () => ApideckMcpCore,
   toolMap: Map<string, ToolDefinition<ZodRawShapeCompat | undefined>>,
   allowedScopes: Set<MCPScope>,
+  analytics?: Analytics,
 ): void {
   // 1. list_tools
   server.registerTool("list_tools", {
@@ -421,14 +448,35 @@ export function registerDynamicTools(
       }
     }
 
+    const start = Date.now();
     try {
-      if (def.args) {
-        return await def.tool(getSDK(), validatedInput, ctx);
-      } else {
-        return await def.tool(getSDK(), ctx);
-      }
+      const result = def.args
+        ? await def.tool(getSDK(), validatedInput, ctx)
+        : await def.tool(getSDK(), ctx);
+      analytics?.capture({
+        distinctId: "mcp-server",
+        event: "mcp_tool_called",
+        properties: {
+          tool_name: args.tool_name,
+          is_error: result.isError ?? false,
+          duration_ms: Date.now() - start,
+          mode: "dynamic",
+        },
+      });
+      return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      analytics?.capture({
+        distinctId: "mcp-server",
+        event: "mcp_tool_called",
+        properties: {
+          tool_name: args.tool_name,
+          is_error: true,
+          error: message,
+          duration_ms: Date.now() - start,
+          mode: "dynamic",
+        },
+      });
       return {
         content: [{
           type: "text",

--- a/worker-configuration.ts
+++ b/worker-configuration.ts
@@ -9,4 +9,5 @@ export interface Env {
   // MY_DURABLE_OBJECT: DurableObjectNamespace;
   APIDECK_MCP_MCP: DurableObjectNamespace;
   ASSETS: Fetcher; // For serving static assets
+  POSTHOG_API_KEY?: string;
 }


### PR DESCRIPTION
- Add lightweight PostHog analytics module (fetch-based, works in Node + CF Workers)
- Track mcp_tool_called events with tool_name, duration, mode, error status
- Wire analytics into createMCPServer, Vercel handler, CF Worker, and serve CLI
- Flush events before Vercel function exits (serverless-safe)
- Use EU PostHog endpoint (eu.i.posthog.com)
- Allow --mode static alongside dynamic (default) in start/serve commands
- Update README to reflect dynamic as default mode
- Add POSTHOG_API_KEY to Env interface and worker-configuration