### PR TITLE
Fix PostHog: create analytics per-request

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -7,7 +7,12 @@ import { createConsoleLogger } from "../src/mcp-server/console-logger.js";
 import { ApideckMcpCore } from "../src/core.js";
 
 const logger = createConsoleLogger("info");
-const analytics = createAnalytics(process.env["POSTHOG_API_KEY"], logger);
+
+function getAnalytics() {
+  const key = process.env["POSTHOG_API_KEY"];
+  logger.info("PostHog init", { hasKey: !!key });
+  return createAnalytics(key, logger);
+}
 
 export const config = {
   maxDuration: 60,
@@ -67,6 +72,7 @@ export default async function handler(req: IncomingMessage & { body?: any }, res
     });
   };
 
+  const analytics = getAnalytics();
   const transport = new StreamableHTTPServerTransport({});
 
   const { server: mcpServer } = createMCPServer({


### PR DESCRIPTION
## Summary
- Move analytics creation inside the Vercel handler so `POSTHOG_API_KEY` is read at request time rather than module-load time
- Fixes events not reaching PostHog in serverless environment

## Test plan
- [ ] Deploy preview, run `MCP_URL=<preview>/mcp npx tsx test/mcp-server.test.ts`
- [ ] Check PostHog Activity tab for `mcp_tool_called` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)