### PR TITLE
Fix PostHog events lost in serverless

### DIFF
--- a/src/mcp-server/analytics.ts
+++ b/src/mcp-server/analytics.ts
@@ -7,44 +7,34 @@ export interface AnalyticsEvent {
 }
 
 export interface Analytics {
-  capture(event: AnalyticsEvent): void;
+  capture(event: AnalyticsEvent): Promise<void>;
   flush(): Promise<void>;
 }
 
 const POSTHOG_API_HOST = "https://eu.i.posthog.com";
-const BATCH_SIZE = 20;
-const FLUSH_INTERVAL_MS = 10_000;
 
 export function createAnalytics(
   apiKey: string | undefined,
   logger: ConsoleLogger,
 ): Analytics {
   if (!apiKey) {
-    return { capture() {}, async flush() {} };
+    return { async capture() {}, async flush() {} };
   }
 
-  const queue: AnalyticsEvent[] = [];
-  let timer: ReturnType<typeof setTimeout> | null = null;
-
-  async function flush() {
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
-    if (queue.length === 0) return;
-
-    const batch = queue.splice(0);
+  async function send(event: AnalyticsEvent) {
     const payload = {
       api_key: apiKey,
-      batch: batch.map((e) => ({
-        event: e.event,
-        distinct_id: e.distinctId,
-        properties: {
-          ...e.properties,
-          $lib: "apideck-mcp",
+      batch: [
+        {
+          event: event.event,
+          distinct_id: event.distinctId,
+          properties: {
+            ...event.properties,
+            $lib: "apideck-mcp",
+          },
+          timestamp: new Date().toISOString(),
         },
-        timestamp: new Date().toISOString(),
-      })),
+      ],
     };
 
     try {
@@ -63,21 +53,10 @@ export function createAnalytics(
     }
   }
 
-  function scheduleFlush() {
-    if (!timer) {
-      timer = setTimeout(() => flush(), FLUSH_INTERVAL_MS);
-    }
-  }
-
   return {
-    capture(event: AnalyticsEvent) {
-      queue.push(event);
-      if (queue.length >= BATCH_SIZE) {
-        flush();
-      } else {
-        scheduleFlush();
-      }
+    async capture(event: AnalyticsEvent) {
+      await send(event);
     },
-    flush,
+    async flush() {},
   };
 }

--- a/src/mcp-server/tools.ts
+++ b/src/mcp-server/tools.ts
@@ -216,7 +216,7 @@ export function createRegisterTool(
         async (args, ctx) => {
           const start = Date.now();
           const result = await tool.tool(getSDK(), args, ctx);
-          analytics?.capture({
+          await analytics?.capture({
             distinctId: "mcp-server",
             event: "mcp_tool_called",
             properties: {
@@ -239,7 +239,7 @@ export function createRegisterTool(
         async (ctx) => {
           const start = Date.now();
           const result = await tool.tool(getSDK(), ctx);
-          analytics?.capture({
+          await analytics?.capture({
             distinctId: "mcp-server",
             event: "mcp_tool_called",
             properties: {


### PR DESCRIPTION
## Summary
- **Root cause**: `StreamableHTTPServerTransport.handlePostRequest()` returns a `Response` wrapping a `ReadableStream` immediately — before tool handlers complete. The old batching approach (queue + 10s `setTimeout`) meant `analytics.flush()` ran while the queue was empty, and the timer never fired before Vercel tore down the function.
- **Fix**: Send each PostHog event immediately on `capture()` instead of batching. In a serverless context with low per-request event volume, this is the correct approach.
- `capture()` is now `async` and awaited in tool handlers, guaranteeing delivery before the handler returns.

## Test plan
- [ ] Deploy preview and trigger tool calls via MCP client
- [ ] Verify `mcp_tool_called` events appear in PostHog Live Events
- [ ] Confirm no regressions in tool response times (single POST to PostHog adds ~50-100ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)