### PR TITLE
Fix PostHog events lost in serverless: await send inline

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -10,7 +10,6 @@ const logger = createConsoleLogger("info");
 
 function getAnalytics() {
   const key = process.env["POSTHOG_API_KEY"];
-  logger.info("PostHog init", { hasKey: !!key });
   return createAnalytics(key, logger);
 }
 
@@ -90,5 +89,4 @@ export default async function handler(req: IncomingMessage & { body?: any }, res
 
   await mcpServer.connect(transport as Transport);
   await transport.handleRequest(req, res, req.body);
-  await analytics.flush();
 }

--- a/src/mcp-server/analytics.ts
+++ b/src/mcp-server/analytics.ts
@@ -21,9 +21,7 @@ export function createAnalytics(
     return { async capture() {}, async flush() {} };
   }
 
-  const pending: Promise<void>[] = [];
-
-  function send(event: AnalyticsEvent): Promise<void> {
+  async function send(event: AnalyticsEvent): Promise<void> {
     const payload = {
       api_key: apiKey,
       batch: [
@@ -39,28 +37,26 @@ export function createAnalytics(
       ],
     };
 
-    return fetch(`${POSTHOG_API_HOST}/batch`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    }).then((res) => {
+    try {
+      const res = await fetch(`${POSTHOG_API_HOST}/batch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
       if (!res.ok) {
         logger.warning("PostHog batch failed", { status: res.status });
       }
-    }).catch((err) => {
+    } catch (err) {
       logger.warning("PostHog batch error", {
         error: err instanceof Error ? err.message : String(err),
       });
-    });
+    }
   }
 
   return {
     async capture(event: AnalyticsEvent) {
-      const p = send(event);
-      pending.push(p);
+      await send(event);
     },
-    async flush() {
-      await Promise.all(pending.splice(0));
-    },
+    async flush() {},
   };
 }

--- a/src/mcp-server/analytics.ts
+++ b/src/mcp-server/analytics.ts
@@ -21,53 +21,46 @@ export function createAnalytics(
     return { async capture() {}, async flush() {} };
   }
 
-  const buffer: Array<{
-    event: string;
-    distinct_id: string;
-    properties: Record<string, unknown>;
-    timestamp: string;
-  }> = [];
+  const pending: Promise<void>[] = [];
 
-  async function sendBatch(
-    batch: typeof buffer,
-  ) {
+  function send(event: AnalyticsEvent): Promise<void> {
     const payload = {
       api_key: apiKey,
-      batch,
+      batch: [
+        {
+          event: event.event,
+          distinct_id: event.distinctId,
+          properties: {
+            ...event.properties,
+            $lib: "apideck-mcp",
+          },
+          timestamp: new Date().toISOString(),
+        },
+      ],
     };
 
-    try {
-      const res = await fetch(`${POSTHOG_API_HOST}/batch`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
+    return fetch(`${POSTHOG_API_HOST}/batch`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then((res) => {
       if (!res.ok) {
         logger.warning("PostHog batch failed", { status: res.status });
       }
-    } catch (err) {
+    }).catch((err) => {
       logger.warning("PostHog batch error", {
         error: err instanceof Error ? err.message : String(err),
       });
-    }
+    });
   }
 
   return {
     async capture(event: AnalyticsEvent) {
-      buffer.push({
-        event: event.event,
-        distinct_id: event.distinctId,
-        properties: {
-          ...event.properties,
-          $lib: "apideck-mcp",
-        },
-        timestamp: new Date().toISOString(),
-      });
+      const p = send(event);
+      pending.push(p);
     },
     async flush() {
-      if (buffer.length === 0) return;
-      const batch = buffer.splice(0);
-      await sendBatch(batch);
+      await Promise.all(pending.splice(0));
     },
   };
 }


### PR DESCRIPTION
## Summary
- **Root cause**: `capture()` fired PostHog fetches without awaiting them. Vercel killed the function after `res.end()` before the fetches completed — events were silently lost.
- **Fix**: `capture()` now `await`s the PostHog `/batch` send inline, so the fetch completes before the tool handler returns. Simple, no buffering needed.
- **Also fixed**: Missing `await` on `analytics?.capture()` calls in the dynamic tool path (`tools.ts`)

## Verified
- Deployed to Vercel preview and triggered `execute_tool` calls
- `mcp_tool_called` events confirmed arriving in PostHog Live Events

## Test plan
- [x] Deploy to Vercel preview and invoke an MCP tool
- [x] Verify `mcp_tool_called` events appear in PostHog Live Events
- [ ] Confirm no regressions in CLI `serve` mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)