### PR TITLE
Use waitUntil for PostHog analytics in serverless

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { waitUntil } from "@vercel/functions";
 import { createAnalytics } from "../src/mcp-server/analytics.js";
 import { createMCPServer } from "../src/mcp-server/server.js";
 import { createConsoleLogger } from "../src/mcp-server/console-logger.js";
@@ -10,7 +11,7 @@ const logger = createConsoleLogger("info");
 
 function getAnalytics() {
   const key = process.env["POSTHOG_API_KEY"];
-  return createAnalytics(key, logger);
+  return createAnalytics(key, logger, waitUntil);
 }
 
 export const config = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.26.0",
         "@stricli/core": "^1.1.2",
+        "@vercel/functions": "^3.4.3",
         "agents": "0.3.10",
         "express": "^5.1.0",
         "zod": "^4.0.0"
@@ -2328,6 +2329,33 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.4.3.tgz",
+      "integrity": "sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw==",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/functions/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.26.0",
     "@stricli/core": "^1.1.2",
+    "@vercel/functions": "^3.4.3",
     "agents": "0.3.10",
     "express": "^5.1.0",
     "zod": "^4.0.0"

--- a/src/mcp-server/analytics.ts
+++ b/src/mcp-server/analytics.ts
@@ -16,12 +16,15 @@ const POSTHOG_API_HOST = "https://eu.i.posthog.com";
 export function createAnalytics(
   apiKey: string | undefined,
   logger: ConsoleLogger,
+  onBackground?: (promise: Promise<unknown>) => void,
 ): Analytics {
   if (!apiKey) {
     return { async capture() {}, async flush() {} };
   }
 
-  async function send(event: AnalyticsEvent): Promise<void> {
+  const pending: Promise<void>[] = [];
+
+  function send(event: AnalyticsEvent): Promise<void> {
     const payload = {
       api_key: apiKey,
       batch: [
@@ -37,26 +40,31 @@ export function createAnalytics(
       ],
     };
 
-    try {
-      const res = await fetch(`${POSTHOG_API_HOST}/batch`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
+    return fetch(`${POSTHOG_API_HOST}/batch`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then((res) => {
       if (!res.ok) {
         logger.warning("PostHog batch failed", { status: res.status });
       }
-    } catch (err) {
+    }).catch((err) => {
       logger.warning("PostHog batch error", {
         error: err instanceof Error ? err.message : String(err),
       });
-    }
+    });
   }
 
   return {
     async capture(event: AnalyticsEvent) {
-      await send(event);
+      const p = send(event);
+      if (onBackground) {
+        onBackground(p);
+      }
+      pending.push(p);
     },
-    async flush() {},
+    async flush() {
+      await Promise.all(pending.splice(0));
+    },
   };
 }


### PR DESCRIPTION
## Summary
- The MCP `StreamableHTTPServerTransport` calls `res.end()` before the handler's async context completes, so Vercel kills the function before PostHog fetches finish — even with `await`.
- Fix: use `waitUntil` from `@vercel/functions` to register each PostHog send, keeping the function alive until delivery completes.
- Each `capture()` fires the fetch immediately and passes the promise to `waitUntil`. No buffering, no flush timing issues.

## Verified on preview
- `mcp_tool_called` events confirmed in PostHog Live Events using `waitUntil` approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)