### PR TITLE
Disable Vercel preview deployments for MCP server

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,9 @@
 {
+  "git": {
+    "deploymentEnabled": {
+      "preview": false
+    }
+  },
   "buildCommand": "",
   "outputDirectory": ".",
   "framework": null,

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,5 @@
 {
-  "git": {
-    "deploymentEnabled": {
-      "preview": false
-    }
-  },
+  "ignoreCommand": "[ \"$VERCEL_ENV\" != \"production\" ]",
   "buildCommand": "",
   "outputDirectory": ".",
   "framework": null,


### PR DESCRIPTION
Preview deploys are unnecessary for an MCP server and were being blocked by speakeasybot not having a linked Vercel account.