### PR TITLE
fix: post-generate pipeline reliability

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,4 +1,4 @@
-name: Generate MCP Server
+name: Generate
 
 permissions:
   checks: write

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,4 +1,4 @@
-name: Generate
+name: Generate MCP Server
 
 permissions:
   checks: write

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,4 +1,4 @@
-name: Generate MCP Server
+name: Generate
 
 permissions:
   checks: write
@@ -31,7 +31,7 @@ jobs:
   post-generate:
     needs: generate
     runs-on: ubuntu-latest
-    if: needs.generate.outputs.has_changes == 'true'
+    if: always() && needs.generate.result == 'success' && needs.generate.outputs.branch_name != ''
     steps:
       - uses: actions/checkout@v4
         with:

--- a/post-generate.sh
+++ b/post-generate.sh
@@ -16,6 +16,13 @@ sed -i.bak '/schemaText += JSON\.stringify(jsonSchema, null, 2);/c\          sch
 sed -i.bak 's/^        const jsonSchema = try/        try/' src/mcp-server/tools.ts
 rm -f src/mcp-server/tools.ts.bak
 
+# Fix 1b: execute_tool — use raw input to prevent binary upload double-parse
+# Speakeasy regen uses `vres.data` (transformed) which breaks base64 uploads.
+# The SDK re-parses input, so we must pass the original untransformed values.
+sed -i.bak 's/const vres = z\.object(def\.args)\.safeParse(args\.input ?? {});/const rawInput = args.input ?? {};\n      const vres = z.object(def.args).safeParse(rawInput);/' src/mcp-server/tools.ts
+sed -i.bak 's/validatedInput = vres\.data;/validatedInput = rawInput;/' src/mcp-server/tools.ts
+rm -f src/mcp-server/tools.ts.bak
+
 # Fix 2: wrangler.toml — fix worker name and use sqlite for free plan
 sed -i.bak 's/name = "@apideck\/mcp-mcp-server"/name = "apideck-mcp-server"/' wrangler.toml
 sed -i.bak 's/new_classes = /new_sqlite_classes = /' wrangler.toml
@@ -28,5 +35,6 @@ rm -f src/mcp-server/cli/start/command.ts.bak src/mcp-server/cli/serve/command.t
 
 echo "Post-generation fixes applied."
 echo "  - tools.ts: describe_tool_input with unrepresentable: 'any' + try/catch"
+echo "  - tools.ts: execute_tool raw input to prevent binary double-parse"
 echo "  - wrangler.toml: worker name + sqlite migration"
 echo "  - start/serve: dynamic mode is now the default"


### PR DESCRIPTION
## Summary
- Fix `post-generate` job condition to use `branch_name` output instead of unreliable `has_changes`, ensuring post-generation patches run when Speakeasy creates a branch
- Add binary upload double-parse patch to `post-generate.sh` — prevents Zod-transformed `vres.data` from breaking base64 file uploads by passing raw untransformed input

## Test plan
- [ ] Trigger workflow manually and verify `post-generate` job runs after `generate` succeeds
- [ ] Confirm `tools.ts` patches apply correctly (describe_tool_input + execute_tool raw input)
- [ ] Test file upload endpoint to verify binary data isn't double-parsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)