### PR TITLE
fix: trigger Vercel production deploy via deploy hook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,3 +25,11 @@ jobs:
 
       - name: Smoke test
         run: node test/smoke.mjs
+
+  deploy:
+    needs: build-and-test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Vercel production deploy
+        run: curl -sS -X POST "${{ secrets.VERCEL_DEPLOY_HOOK_URL }}"


### PR DESCRIPTION
## Summary
- Adds a `deploy` job to CI that triggers a Vercel deploy hook after build and smoke test pass
- Only fires on push to `main`, not on PRs or manual dispatch
- Fixes unreliable production deploys from the Vercel GitHub integration

## Prerequisites
1. Create a deploy hook in Vercel (Project Settings → Git → Deploy Hooks, branch `main`)
2. Add the URL as a GitHub secret: `gh secret set VERCEL_DEPLOY_HOOK_URL`

## Test plan
- [ ] Verify deploy hook is created in Vercel and secret is set in GitHub
- [ ] Merge to main and confirm Vercel production deployment triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)