### PR TITLE
fix: remove ignoreCommand blocking deploy hook builds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "ignoreCommand": "[ \"$VERCEL_ENV\" != \"production\" ]",
   "buildCommand": "",
   "outputDirectory": ".",
   "framework": null,


### PR DESCRIPTION
## Summary
- Removes `ignoreCommand` from `vercel.json` that was blocking deploy hook-triggered builds
- Deploy hooks may not set `VERCEL_ENV=production`, causing the ignore check to skip the build
- Safe to remove since deploys are now gated by CI (only fires on push to main via #23)

## Test plan
- [ ] Merge to main and confirm Vercel production deployment triggers successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)