### PR TITLE
fix: restore Vercel deployment (missing @vercel/functions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/bin
-/esm
 **/.speakeasy/logs/
 **/.speakeasy/reports/
 **/.speakeasy/temp/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,22 @@
 {
   "name": "@apideck/mcp",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apideck/mcp",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.26.0",
         "@stricli/core": "^1.1.2",
+        "@vercel/functions": "^3.4.3",
         "agents": "0.3.10",
         "express": "^5.1.0",
         "zod": "^4.0.0"
       },
       "bin": {
-        "mcp": "bin/mcp-server.js"
+        "apideck-mcp": "bin/mcp-server.js"
       },
       "devDependencies": {
         "@anthropic-ai/mcpb": "^1.2.0",
@@ -2329,6 +2330,35 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.4.3.tgz",
+      "integrity": "sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/functions/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.26.0",
     "@stricli/core": "^1.1.2",
+    "@vercel/functions": "^3.4.3",
     "agents": "0.3.10",
     "express": "^5.1.0",
     "zod": "^4.0.0"

--- a/post-generate.sh
+++ b/post-generate.sh
@@ -33,8 +33,22 @@ sed -i.bak 's/values: \["dynamic"\],$/values: ["dynamic"],\n        default: "dy
 sed -i.bak 's/values: \["dynamic"\],$/values: ["dynamic"],\n        default: "dynamic",/' src/mcp-server/cli/serve/command.ts
 rm -f src/mcp-server/cli/start/command.ts.bak src/mcp-server/cli/serve/command.ts.bak
 
+# Fix 4: Restore Vercel deployment requirements
+# Speakeasy regen overwrites package.json (dropping @vercel/functions)
+# and .gitignore (adding /bin and /esm which must be tracked for Vercel
+# since buildCommand is empty).
+if ! grep -q '@vercel/functions' package.json; then
+  sed -i.bak 's/"@stricli\/core": "\^1.1.2",/"@stricli\/core": "^1.1.2",\n    "@vercel\/functions": "^3.4.3",/' package.json
+  rm -f package.json.bak
+  echo "  - package.json: restored @vercel/functions dependency"
+fi
+sed -i.bak '/^\/bin$/d; /^\/esm$/d' .gitignore
+rm -f .gitignore.bak
+
 echo "Post-generation fixes applied."
 echo "  - tools.ts: describe_tool_input with unrepresentable: 'any' + try/catch"
 echo "  - tools.ts: execute_tool raw input to prevent binary double-parse"
 echo "  - wrangler.toml: worker name + sqlite migration"
 echo "  - start/serve: dynamic mode is now the default"
+echo "  - package.json: @vercel/functions dependency preserved"
+echo "  - .gitignore: /bin and /esm kept tracked for Vercel deploy"


### PR DESCRIPTION
## Summary

- Restore `@vercel/functions` dependency removed by Speakeasy regen — the missing import causes `FUNCTION_INVOCATION_FAILED` (500) at startup
- Remove `/bin` and `/esm` from `.gitignore` so compiled output stays tracked (required since `buildCommand` is empty)
- Add Fix 4 to `post-generate.sh` to automatically restore both after every `speakeasy run`

## Root cause

Commit `6281df8` fixed this, but Speakeasy regen `653c15e` overwrote both `package.json` and `.gitignore`, breaking the deploy again. The post-generate script now prevents this from recurring.

## Test plan

- [x] Local MCP server starts and responds to `initialize`
- [ ] Verify Vercel deployment succeeds after merge
- [ ] Verify `https://mcp.apideck.dev/mcp` returns 200 on GET

🤖 Generated with [Claude Code](https://claude.com/claude-code)