### PR TITLE
Publish to the official MCP registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yaml
+++ b/.github/workflows/publish-mcp-registry.yaml
@@ -1,0 +1,78 @@
+name: Publish to MCP Registry
+
+# Runs after the npm publish workflow completes successfully, syncs the version
+# in server.json to match what was just published on npm, and pushes to the
+# official MCP registry at registry.modelcontextprotocol.io.
+#
+# One-time setup required:
+#   1. Generate an Ed25519 keypair (e.g. `openssl genpkey -algorithm Ed25519`).
+#   2. Publish the public key as a DNS TXT record on apideck.com:
+#        apideck.com. IN TXT "v=MCPv1; k=ed25519; p=<BASE64_PUBKEY>"
+#   3. Add the private key (hex) as the `MCP_REGISTRY_PRIVATE_KEY` repo secret.
+
+permissions:
+  contents: read
+
+"on":
+  workflow_run:
+    workflows: ["Publish to npm"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Sync server.json version to package.json
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          echo "Syncing server.json to version $VERSION"
+          jq --arg v "$VERSION" \
+            '.version = $v | .packages[0].version = $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+
+      - name: Wait for npm propagation
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          for i in 1 2 3 4 5 6; do
+            if npm view "@apideck/mcp@$VERSION" version > /dev/null 2>&1; then
+              echo "Package @apideck/mcp@$VERSION is live on npm"
+              exit 0
+            fi
+            echo "Not yet on npm, retrying in 10s... ($i/6)"
+            sleep 10
+          done
+          echo "::error::Package @apideck/mcp@$VERSION never appeared on npm"
+          exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}_${ARCH}.tar.gz" \
+            | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+          mcp-publisher --help
+
+      - name: Authenticate with MCP Registry (DNS)
+        run: mcp-publisher login dns --domain=apideck.com --private-key="$MCP_REGISTRY_PRIVATE_KEY"
+        env:
+          MCP_REGISTRY_PRIVATE_KEY: ${{ secrets.MCP_REGISTRY_PRIVATE_KEY }}
+
+      - name: Publish
+        run: mcp-publisher publish
+
+      - name: Verify in registry
+        run: |
+          sleep 5
+          curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=com.apideck/mcp" | jq .

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ speakeasy-spec.yml
 .vercel
 docs/superpowers/
 .claude/settings.local.json
+
+# Private keys (e.g. mcp-registry Ed25519 for namespace auth)
+*.key
+*.pem
+
+# Local-only drafts (blog posts, notes)
+/drafts/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@ Every major agent framework (OpenAI Agents SDK, Pydantic AI, LangChain, CrewAI, 
 agent = Agent(name="AP Agent", mcp_servers=[apideck_mcp])
 ```
 
-Xero, Stripe, and Intuit all ship MCP servers for this reason. Apideck's Unified API — covering 100+ connectors across accounting systems, HRIS platforms, and more through one integration — is a natural fit.
+Xero, Stripe, and Intuit all ship MCP servers for this reason. Apideck's Unified API — covering 200+ connectors across accounting systems, HRIS platforms, and more through one integration — is a natural fit.
 
 ## MCP + CLI: Complementary, Not Competing
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@ Every major agent framework (OpenAI Agents SDK, Pydantic AI, LangChain, CrewAI, 
 agent = Agent(name="AP Agent", mcp_servers=[apideck_mcp])
 ```
 
-Xero, Stripe, and Intuit all ship MCP servers for this reason. Apideck's Unified API — covering 20+ accounting systems, HRIS platforms, and more through one integration — is a natural fit.
+Xero, Stripe, and Intuit all ship MCP servers for this reason. Apideck's Unified API — covering 100+ connectors across accounting systems, HRIS platforms, and more through one integration — is a natural fit.
 
 ## MCP + CLI: Complementary, Not Competing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apideck MCP Server
 
-Model Context Protocol server for the [Apideck Unified API](https://www.apideck.com). Connect any MCP-compatible agent framework to 100+ connectors — accounting systems, HRIS platforms, file storage providers, and more — through one integration.
+Model Context Protocol server for the [Apideck Unified API](https://www.apideck.com). Connect any MCP-compatible agent framework to 200+ connectors — accounting systems, HRIS platforms, file storage providers, and more — through one integration.
 
 Generated from Apideck's OpenAPI spec using [Speakeasy](https://www.speakeasy.com).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apideck MCP Server
 
-Model Context Protocol server for the [Apideck Unified API](https://www.apideck.com). Connect any MCP-compatible agent framework to 20+ accounting systems, HRIS platforms, file storage providers, and more through one integration.
+Model Context Protocol server for the [Apideck Unified API](https://www.apideck.com). Connect any MCP-compatible agent framework to 100+ connectors — accounting systems, HRIS platforms, file storage providers, and more — through one integration.
 
 Generated from Apideck's OpenAPI spec using [Speakeasy](https://www.speakeasy.com).
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@apideck/mcp",
+  "mcpName": "com.apideck/mcp",
   "version": "0.1.10",
   "author": "Apideck",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "source": "github"
   },
   "version": "0.1.10",
-  "websiteUrl": "https://www.apideck.com",
+  "websiteUrl": "https://www.apideck.com/mcp-server",
   "packages": [
     {
       "registryType": "npm",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.apideck/mcp",
-  "description": "MCP server for the Apideck Unified API — Accounting, File Storage, HRIS, Vault, and Proxy tools across 100+ connectors (QuickBooks, Xero, NetSuite, Sage, BambooHR, and more). 229 auto-generated tools with dynamic discovery.",
+  "description": "MCP server for the Apideck Unified API — Accounting, File Storage, HRIS, Vault, and Proxy tools across 200+ connectors (QuickBooks, Xero, NetSuite, Sage, BambooHR, and more). 229 auto-generated tools with dynamic discovery.",
   "repository": {
     "url": "https://github.com/apideck-libraries/mcp",
     "source": "github"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.apideck/mcp",
+  "description": "MCP server for the Apideck Unified API — Accounting, File Storage, HRIS, Vault, and Proxy tools across 100+ connectors (QuickBooks, Xero, NetSuite, Sage, BambooHR, and more). 229 auto-generated tools with dynamic discovery.",
+  "repository": {
+    "url": "https://github.com/apideck-libraries/mcp",
+    "source": "github"
+  },
+  "version": "0.1.10",
+  "websiteUrl": "https://www.apideck.com",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@apideck/mcp",
+      "version": "0.1.10",
+      "runtimeHint": "npx",
+      "transport": { "type": "stdio" },
+      "environmentVariables": [
+        {
+          "name": "APIDECK_API_KEY",
+          "description": "Your Apideck API key (from https://platform.apideck.com/configuration/api-keys).",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "APIDECK_APP_ID",
+          "description": "Your Apideck application ID (from https://platform.apideck.com/configuration/api-keys).",
+          "isRequired": true
+        },
+        {
+          "name": "APIDECK_CONSUMER_ID",
+          "description": "The end-user/customer ID whose Vault connections should be used.",
+          "isRequired": true
+        }
+      ]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.apideck.dev/mcp",
+      "headers": [
+        {
+          "name": "x-apideck-api-key",
+          "description": "Your Apideck API key.",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "x-apideck-app-id",
+          "description": "Your Apideck application ID.",
+          "isRequired": true
+        },
+        {
+          "name": "x-apideck-consumer-id",
+          "description": "The end-user/customer ID whose Vault connections should be used.",
+          "isRequired": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the config and CI workflow needed to publish `@apideck/mcp` to [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) under the `com.apideck/mcp` namespace — the same pattern Stripe, Notion, and Atlassian use for their official MCP servers.

- **`server.json`** — registry manifest declaring both the npm package (`@apideck/mcp`, stdio transport) and the hosted remote at `https://mcp.apideck.dev/mcp`, with env var and header schemas for both.
- **`package.json`** — adds `mcpName: "com.apideck/mcp"` so the registry can cross-validate against the published npm package.
- **`.github/workflows/publish-mcp-registry.yaml`** — runs after "Publish to npm" completes successfully, syncs `server.json` version to `package.json`, polls npm for propagation, installs `mcp-publisher`, authenticates via DNS, and publishes.
- **`.gitignore`** — ignore `*.key`/`*.pem` so the registry private key can't be committed, plus `/drafts/` for local-only blog posts and notes.
- **`README.md` / `ARCHITECTURE.md` / `server.json`** — bump connector count from 20+ to 100+ to match current coverage.

## Namespace

Publishing under `com.apideck/mcp`, claimed via Ed25519 DNS TXT record on `apideck.com`:

```
apideck.com. IN TXT "v=MCPv1; k=ed25519; p=13VFCrA+8NZkE4UUwcSBOfl4q6CVqq6rQldxddbvE94="
```

## Test plan

- [ ] Merge this PR
- [ ] Next npm publish (on `.speakeasy/gen.lock` change) fires "Publish to npm", which chains into "Publish to MCP Registry" via `workflow_run`
- [ ] Verify the listing at https://registry.modelcontextprotocol.io/v0.1/servers?search=com.apideck/mcp
- [ ] Confirm env vars render correctly in Claude Desktop / Cursor once clients pick up the new listing

## Not included (follow-ups)

- TDQS description improvements to the four dynamic meta-tools — separate PR
- Smithery listing sync (make sure env vars / description match `server.json`)
- Submissions to PulseMCP, MCP.so, and the `modelcontextprotocol/servers` awesome-list

🤖 Generated with [Claude Code](https://claude.com/claude-code)