### PR TITLE
Shorten server.json description to fit MCP registry 100-char limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apideck/mcp",
   "mcpName": "com.apideck/mcp",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "author": "Apideck",
   "type": "module",
   "sideEffects": false,

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.apideck/mcp",
-  "description": "MCP server for the Apideck Unified API — Accounting, File Storage, HRIS, Vault, and Proxy tools across 200+ connectors (QuickBooks, Xero, NetSuite, Sage, BambooHR, and more). 229 auto-generated tools with dynamic discovery.",
+  "description": "Apideck Unified API MCP — 229 tools across 200+ SaaS connectors (accounting, HRIS, file storage).",
   "repository": {
     "url": "https://github.com/apideck-libraries/mcp",
     "source": "github"

--- a/server.json
+++ b/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/apideck-libraries/mcp",
     "source": "github"
   },
-  "version": "0.1.10",
+  "version": "0.1.11",
   "websiteUrl": "https://www.apideck.com/mcp-server",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@apideck/mcp",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "runtimeHint": "npx",
       "transport": { "type": "stdio" },
       "environmentVariables": [


### PR DESCRIPTION
## Summary
The MCP registry schema caps \`description\` at 100 characters. Our current 192-char string causes every publish to fail with HTTP 422:

\`\`\`
expected length <= 100 at body.description
\`\`\`

That's why \`com.apideck/mcp\` has never shown up in the registry. Shortening to 97 chars.

## Test plan
- [ ] After merge, re-dispatch the "Publish to MCP Registry" workflow (\`gh workflow run publish-mcp-registry.yaml\`) and verify \`curl https://registry.modelcontextprotocol.io/v0/servers/com.apideck%2Fmcp/versions\` returns the record.

Companion to #30 which also updates the description (and must be shortened on merge).