### PR TITLE
Add glama.json for Glama server claim

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "Gdewilde"
+  ]
+}

--- a/glama.json
+++ b/glama.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "maintainers": [
-    "Gdewilde"
+    "Gdewilde",
+    "Amzani"
   ]
 }


### PR DESCRIPTION
Adds the Glama claim manifest so we can manage the Apideck MCP listing on [glama.ai](https://glama.ai/mcp/connectors/dev.apideck.mcp/apideck-mcp).

Follows the format at the root of the repo as documented on Glama's claim flow:

\`\`\`json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["Gdewilde"]
}
\`\`\`

After merge:
1. Log in on glama.ai with the `Gdewilde` GitHub account
2. Hit "Login with GitHub to claim" on the server page
3. Glama verifies the maintainer entry and grants edit rights (description, scoring notifications, Docker build instructions)
