### PR TITLE
Add mcp.json for Open Plugins auto-detection

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,23 @@
+{
+  "mcpServers": {
+    "apideck": {
+      "type": "http",
+      "url": "https://mcp.apideck.dev/mcp",
+      "headers": {
+        "x-apideck-api-key": "${APIDECK_API_KEY}",
+        "x-apideck-app-id": "${APIDECK_APP_ID}",
+        "x-apideck-consumer-id": "${APIDECK_CONSUMER_ID}"
+      }
+    },
+    "apideck-stdio": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@apideck/mcp"],
+      "env": {
+        "APIDECK_API_KEY": "${APIDECK_API_KEY}",
+        "APIDECK_APP_ID": "${APIDECK_APP_ID}",
+        "APIDECK_CONSUMER_ID": "${APIDECK_CONSUMER_ID}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Open Plugins (open-plugins.com) auto-detect scans the repo root for `mcp.json` or `.mcp.json` to register an MCP server entry. Without it the scanner fails with:

> No plugin components found in: repo root. We looked for: rules/*.mdc, .mcp.json or mcp.json, skills/*/SKILL.md, agents/*.md, commands/*.md, hooks/hooks.json, .lsp.json

This PR adds a minimal `mcp.json` declaring two variants:

- `apideck` — HTTP transport at `mcp.apideck.dev/mcp` (hosted, recommended)
- `apideck-stdio` — stdio via `npx -y @apideck/mcp`

Both read credentials from the standard `APIDECK_API_KEY` / `APIDECK_APP_ID` / `APIDECK_CONSUMER_ID` env vars, matching what's already documented in README.
