### PR TITLE
Add Dockerfile + entrypoint for hosted container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Minimal container image for the Apideck MCP server.
+#
+# Runs the stdio transport by default (what MCP clients like Claude
+# Desktop, Cursor, and Glama's introspector expect). The entrypoint
+# forwards APIDECK_* env vars as CLI flags so `docker run -e ... image`
+# works without a wrapper script.
+#
+# Usage (with creds for real API calls):
+#
+#   docker run -i --rm \
+#     -e APIDECK_API_KEY=sk_live_... \
+#     -e APIDECK_APP_ID=... \
+#     -e APIDECK_CONSUMER_ID=... \
+#     ghcr.io/apideck-libraries/mcp
+#
+# Usage (introspection only — no creds needed):
+#
+#   docker run -i --rm ghcr.io/apideck-libraries/mcp
+#
+FROM node:20-alpine
+
+# `@apideck/mcp` pins its version via npm; update the tag in CI when
+# publishing a new release.
+ARG APIDECK_MCP_VERSION=latest
+RUN npm install -g "@apideck/mcp@${APIDECK_MCP_VERSION}"
+
+# Smoke that the binary was installed correctly so the image fails to
+# build rather than at runtime.
+RUN mcp --help > /dev/null
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Forwards APIDECK_* env vars as --flag values to `mcp start` so the
+# container can be configured via standard Docker env-var conventions.
+#
+# Any additional CLI args passed to `docker run <image> …` are appended
+# after the auto-expanded flags, letting callers override transport,
+# log-level, scope, etc.
+set -e
+
+args="start --transport stdio"
+
+if [ -n "${APIDECK_API_KEY}" ]; then
+  args="$args --api-key $APIDECK_API_KEY"
+fi
+if [ -n "${APIDECK_APP_ID}" ]; then
+  args="$args --app-id $APIDECK_APP_ID"
+fi
+if [ -n "${APIDECK_CONSUMER_ID}" ]; then
+  args="$args --consumer-id $APIDECK_CONSUMER_ID"
+fi
+
+# shellcheck disable=SC2086
+exec mcp $args "$@"


### PR DESCRIPTION
Minimal `node:20-alpine` image that installs the published `@apideck/mcp` from npm and runs `mcp start --transport stdio` by default — the path MCP clients (Claude Desktop, Cursor, Glama's introspector) expect.

`docker-entrypoint.sh` forwards `APIDECK_*` env vars as CLI flags so the container is configurable via standard Docker conventions:

```bash
docker run -i --rm \
  -e APIDECK_API_KEY=sk_live_... \
  -e APIDECK_APP_ID=... \
  -e APIDECK_CONSUMER_ID=... \
  <image>
```

Also starts without credentials — auth flags are optional on `mcp start` — so Glama's quality/security scorer can introspect the server (list tools, describe inputs) without real creds. That's what unblocks the A/A/A score on the Glama listing.

## Sizes (estimate)

- Base image `node:20-alpine`: ~175 MB
- `@apideck/mcp` + deps: ~35 MB
- Total: ~210 MB compressed

## After merge

1. Glama's introspection should succeed when the repo is claimed — the Dockerfile is discoverable in the repo root
2. For a published image we'd add a separate workflow that builds + pushes to `ghcr.io/apideck-libraries/mcp` on release tags (not in this PR)
