### PR TITLE
Add MCP ecosystem badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Apideck MCP Server
 
+[![npm version](https://img.shields.io/npm/v/%40apideck%2Fmcp?logo=npm&label=%40apideck%2Fmcp)](https://www.npmjs.com/package/@apideck/mcp)
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-com.apideck%2Fmcp-blue)](https://registry.modelcontextprotocol.io/v0/servers/com.apideck%2Fmcp/versions)
+[![Glama score](https://glama.ai/mcp/servers/apideck-libraries/mcp/badges/score.svg)](https://glama.ai/mcp/servers/apideck-libraries/mcp)
+[![CI](https://github.com/apideck-libraries/mcp/actions/workflows/ci.yaml/badge.svg)](https://github.com/apideck-libraries/mcp/actions/workflows/ci.yaml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 Model Context Protocol server for the [Apideck Unified API](https://www.apideck.com). Connect any MCP-compatible agent framework to 200+ connectors — accounting systems, HRIS platforms, file storage providers, and more — through one integration.
 
 Generated from Apideck's OpenAPI spec using [Speakeasy](https://www.speakeasy.com).


### PR DESCRIPTION
Five shields at the top of the README matching the conventions other MCP servers use in the [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) list:

| Badge | Source | Links to |
|---|---|---|
| npm version | shields.io | [`@apideck/mcp` on npm](https://www.npmjs.com/package/@apideck/mcp) |
| MCP Registry | shields.io | [`com.apideck/mcp` at registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/v0/servers/com.apideck%2Fmcp/versions) |
| Glama score | glama.ai | [Glama server page](https://glama.ai/mcp/servers/apideck-libraries/mcp) — renders the A/A/A score once Glama's scorer runs |
| CI | GitHub Actions | the [`ci.yaml` workflow](https://github.com/apideck-libraries/mcp/actions/workflows/ci.yaml) |
| MIT license | shields.io | OSI page |

Glama's badge URL currently 404s until their crawler picks up [punkpeye/awesome-mcp-servers#5281](https://github.com/punkpeye/awesome-mcp-servers/pull/5281), which is in flight. Once merged + scored, the badge auto-renders inline.
