### PR TITLE
Code-sandbox mode: apideck_search + apideck_run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
           node test/gen-server.test.mjs
           node test/gen-extras.test.mjs
           node test/gen-handler-e2e.test.mjs
+          node test/gen-sandbox.test.mjs
 
   deploy:
     needs: build-and-test

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -76,15 +76,26 @@ export default async function handler(req: IncomingMessage & { body?: any }, res
   const analytics = getAnalytics();
   const transport = new StreamableHTTPServerTransport({});
 
-  // Custom generator is the default. Pass `?engine=legacy` to fall back.
+  // Custom generator is the default. Query knobs:
+  //   ?engine=legacy  → fall back to the legacy (Speakeasy) MCP server
+  //   ?mode=code      → serve only apideck_search + apideck_run (see src/gen/code-tools.ts)
   const url = new URL(req.url ?? "", "http://localhost");
   const engine = url.searchParams.get("engine");
+  const mode = url.searchParams.get("mode");
   const useLegacy = engine === "legacy";
+  const codeMode = mode === "code";
   if (useLegacy) logger.info("Using legacy generator engine");
+  if (codeMode) logger.info("Using code-sandbox mode");
 
   const { server: mcpServer } = useLegacy
     ? createMCPServer({ logger, analytics, dynamic: true, getSDK })
-    : createGeneratedMCPServer({ logger, analytics, dynamic: true, getSDK });
+    : createGeneratedMCPServer({
+      logger,
+      analytics,
+      dynamic: !codeMode,
+      codeMode,
+      getSDK,
+    });
 
   mcpServer.server.onerror = (error: unknown) => {
     logger.error("MCP error", {

--- a/src/gen/code-tools.ts
+++ b/src/gen/code-tools.ts
@@ -1,0 +1,105 @@
+/**
+ * Two meta-tools for code-orchestrated agents.
+ *
+ * Follows the pattern described in Anthropic's "building agents that
+ * reach production systems with MCP" post — a thin tool surface that
+ * the agent drives by writing code, instead of materialising 330
+ * individual tool definitions into context.
+ *
+ *   apideck_search(query)  — browse the Apideck endpoint catalog
+ *   apideck_run(script)    — run a short async script against the
+ *                            bound `apideck.*` SDK in a sandbox, return
+ *                            just the final value
+ */
+
+import * as z from "zod";
+import type { ToolDefinition } from "../mcp-server/tools.js";
+import { runScript, searchTools } from "./sandbox.js";
+
+export const apideckSearch: ToolDefinition<{
+  query: z.ZodOptional<z.ZodString>;
+}> = {
+  name: "apideck_search",
+  description:
+    "Search the Apideck endpoint catalog. Returns matching endpoints as "
+    + "{ name, method, description, scopes } so you can decide which ones "
+    + "to call from apideck_run. Pass a space-separated query, e.g. "
+    + "\"invoices list\" or \"employees create\". Omit the query to list everything.",
+  scopes: ["read"],
+  annotations: {
+    title: "Search Apideck endpoints",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  args: {
+    query: z.string().optional().describe(
+      "Space-separated search terms matched against endpoint name, description, and scope. Omit to list all endpoints.",
+    ),
+  },
+  async tool(_client, args) {
+    const results = searchTools(args.query ?? "");
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify(
+          { count: results.length, endpoints: results },
+          null,
+          2,
+        ),
+      }],
+    };
+  },
+};
+
+export const apideckRun: ToolDefinition<{
+  script: z.ZodString;
+  timeout_ms: z.ZodOptional<z.ZodNumber>;
+}> = {
+  name: "apideck_run",
+  description: [
+    "Run a short async JavaScript snippet against Apideck's 330 endpoints.",
+    "",
+    "Inside the sandbox you have an `apideck` object with camelCase methods for every endpoint — ",
+    "e.g. `apideck.accountingInvoicesList({ limit: 10 })`, `apideck.vaultConnectionsList({})`. ",
+    "Each method takes the endpoint's `request` shape (path + query + header + body fields, flat) ",
+    "and returns the parsed JSON response body. Errors throw.",
+    "",
+    "Use `apideck_search` first to find the method name you need. The script runs to completion ",
+    "and only its returned value reaches you — chain, filter, and aggregate in code rather than ",
+    "in separate tool calls.",
+    "",
+    "Available top-level helpers: `console.log` (captured and returned alongside the result), ",
+    "`JSON`, `Promise`, `setTimeout`, `Date`, `Math`.",
+    "",
+    "Example:",
+    "```js",
+    "const invoices = await apideck.accountingInvoicesList({ limit: 50 });",
+    "const overdue = invoices.data.filter(i => new Date(i.due_date) < new Date() && i.status !== 'paid');",
+    "return { count: overdue.length, totalOutstanding: overdue.reduce((s, i) => s + i.balance, 0) };",
+    "```",
+  ].join("\n"),
+  scopes: ["read", "write", "destructive"],
+  annotations: {
+    title: "Run code against Apideck",
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  args: {
+    script: z.string().describe(
+      "Async JavaScript snippet. Top-level `await` and `return` are allowed — the snippet is wrapped in an async IIFE.",
+    ),
+    timeout_ms: z.number().int().min(1000).max(120_000).optional().describe(
+      "Max wall-clock time for the script in milliseconds. Defaults to 30000.",
+    ),
+  },
+  async tool(client, args, ctx) {
+    return runScript(client, args.script, {
+      signal: ctx.signal,
+      timeoutMs: args.timeout_ms,
+    });
+  },
+};

--- a/src/gen/create-server.ts
+++ b/src/gen/create-server.ts
@@ -17,12 +17,19 @@ import {
   MCPToolAnnotationFilter,
   registerDynamicTools,
 } from "../mcp-server/tools.js";
+import { apideckRun, apideckSearch } from "./code-tools.js";
 import { generatedTools } from "./tools.js";
 
 export function createGeneratedMCPServer(deps: {
   logger: ConsoleLogger;
   allowedTools?: string[] | undefined;
   dynamic?: boolean | undefined;
+  /**
+   * When true, register only `apideck_search` + `apideck_run` instead of
+   * the 330 individual tools. The agent drives Apideck by writing code
+   * against a bound `apideck.*` SDK — see src/gen/sandbox.ts.
+   */
+  codeMode?: boolean | undefined;
   scopes?: MCPScope[] | undefined;
   annotationFilter?: MCPToolAnnotationFilter | undefined;
   getSDK: () => ApideckMcpCore;
@@ -43,10 +50,14 @@ export function createGeneratedMCPServer(deps: {
     deps.analytics,
   );
 
-  for (const t of generatedTools) tool(t);
-
-  if (deps.dynamic) {
-    registerDynamicTools(deps.logger, server, deps.getSDK, toolMap, scopes, deps.analytics);
+  if (deps.codeMode) {
+    tool(apideckSearch);
+    tool(apideckRun);
+  } else {
+    for (const t of generatedTools) tool(t);
+    if (deps.dynamic) {
+      registerDynamicTools(deps.logger, server, deps.getSDK, toolMap, scopes, deps.analytics);
+    }
   }
 
   return { server, tools };

--- a/src/gen/sandbox.ts
+++ b/src/gen/sandbox.ts
@@ -1,0 +1,183 @@
+/**
+ * Sandboxed code execution for the `apideck_run` meta-tool.
+ *
+ * Exposes every generated tool as a callable method on an `apideck` object
+ * inside an isolated vm.Context. The agent writes a short async script that
+ * chains / aggregates / filters endpoint results; only the script's final
+ * returned value reaches the model's context.
+ *
+ * Not hardened against adversarial scripts — this is designed for the same
+ * threat model as our hosted tool path (the caller authenticates with an
+ * Apideck API key). Node's `vm` module does not provide true isolation;
+ * if that becomes a requirement we'd swap in `worker_threads` or a true
+ * sandbox runtime.
+ */
+
+import * as vm from "node:vm";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ApideckMcpCore } from "../core.js";
+import { generatedTools } from "./tools.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Convert `accounting-aged-creditors-get` → `accountingAgedCreditorsGet`. */
+function toolNameToMethod(name: string): string {
+  return name
+    .split("-")
+    .map((part, i) =>
+      i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1),
+    )
+    .join("");
+}
+
+/** Build the `apideck` object exposed to the sandboxed script. */
+function buildApideckBinding(
+  client: ApideckMcpCore,
+  signal: AbortSignal,
+): Record<string, (args?: unknown) => Promise<unknown>> {
+  const bindings: Record<string, (args?: unknown) => Promise<unknown>> = {};
+  for (const tool of generatedTools) {
+    const method = toolNameToMethod(tool.name);
+    bindings[method] = async (args: unknown = {}) => {
+      const result = await (tool as { tool: (c: ApideckMcpCore, a: unknown, ctx: { signal: AbortSignal }) => Promise<CallToolResult> }).tool(
+        client,
+        { request: args },
+        { signal },
+      );
+      // Unwrap: scripts almost always want the parsed JSON body, not an
+      // MCP content envelope. Fall back to raw text if parse fails.
+      const text = result.content?.[0] && "text" in result.content[0]
+        ? (result.content[0] as { text: string }).text
+        : "";
+      if (result.isError) {
+        const err = new Error(text || "Apideck API error");
+        (err as { apideck?: unknown }).apideck = safeParse(text);
+        throw err;
+      }
+      return safeParse(text) ?? text;
+    };
+  }
+  return bindings;
+}
+
+function safeParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+/** Collect console.log output so the script can emit progress / debug info. */
+function buildConsole(logs: string[]): Console {
+  const stringify = (args: unknown[]): string =>
+    args
+      .map((a) =>
+        typeof a === "string"
+          ? a
+          : a instanceof Error
+          ? a.stack ?? a.message
+          : JSON.stringify(a),
+      )
+      .join(" ");
+  return {
+    log: (...a: unknown[]) => logs.push(stringify(a)),
+    warn: (...a: unknown[]) => logs.push("[warn] " + stringify(a)),
+    error: (...a: unknown[]) => logs.push("[error] " + stringify(a)),
+    info: (...a: unknown[]) => logs.push(stringify(a)),
+    debug: () => {},
+  } as unknown as Console;
+}
+
+export interface RunScriptOptions {
+  signal?: AbortSignal | undefined;
+  timeoutMs?: number | undefined;
+}
+
+export async function runScript(
+  client: ApideckMcpCore,
+  script: string,
+  options: RunScriptOptions = {},
+): Promise<CallToolResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const ctrl = new AbortController();
+  const abortOnParent = () => ctrl.abort();
+  options.signal?.addEventListener("abort", abortOnParent, { once: true });
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+
+  const logs: string[] = [];
+  const apideck = buildApideckBinding(client, ctrl.signal);
+
+  const context = vm.createContext({
+    apideck,
+    console: buildConsole(logs),
+    JSON,
+    Promise,
+    setTimeout,
+    clearTimeout,
+    Date,
+    Math,
+    // AbortSignal is exposed so scripts can coordinate their own cancellation
+    AbortSignal,
+  });
+
+  // Wrap the user's script in an async IIFE so top-level `await` works and
+  // the return value propagates out.
+  const wrapped = `(async () => { ${script}\n })()`;
+
+  try {
+    const promise = vm.runInContext(wrapped, context, {
+      timeout: timeoutMs,
+      filename: "apideck-script.js",
+    }) as Promise<unknown>;
+    const result = await promise;
+
+    const payload = {
+      result: result === undefined ? null : result,
+      ...(logs.length > 0 ? { logs } : {}),
+    };
+    return {
+      content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify(
+          {
+            error: message,
+            ...(logs.length > 0 ? { logs } : {}),
+          },
+          null,
+          2,
+        ),
+      }],
+      isError: true,
+    };
+  } finally {
+    clearTimeout(timer);
+    options.signal?.removeEventListener("abort", abortOnParent);
+  }
+}
+
+/** Search the generated tool catalog by name/description/scope substring match. */
+export function searchTools(
+  query: string,
+): Array<{ name: string; method: string; description: string; scopes: string[] }> {
+  const q = query.trim().toLowerCase();
+  const terms = q ? q.split(/\s+/) : [];
+  const out: Array<{ name: string; method: string; description: string; scopes: string[] }> = [];
+  for (const t of generatedTools) {
+    const haystack = `${t.name} ${t.description} ${(t.scopes ?? []).join(" ")}`.toLowerCase();
+    if (terms.length === 0 || terms.some((term) => haystack.includes(term))) {
+      out.push({
+        name: t.name,
+        method: toolNameToMethod(t.name),
+        description: t.description,
+        scopes: (t.scopes ?? []) as string[],
+      });
+    }
+  }
+  return out;
+}

--- a/test/gen-sandbox-live.mjs
+++ b/test/gen-sandbox-live.mjs
@@ -1,0 +1,55 @@
+/**
+ * Live integration check: run a real `apideck_run` script against
+ * unify.apideck.com and show the result.
+ *
+ *   node --env-file=.env.local test/gen-sandbox-live.mjs
+ */
+
+import { ApideckMcpCore } from "../esm/src/core.js";
+import { createGeneratedMCPServer } from "../esm/src/gen/create-server.js";
+
+const apiKey = process.env.APIDECK_API_KEY;
+const appId = process.env.APIDECK_APP_ID;
+const consumerId = process.env.APIDECK_CONSUMER_ID;
+if (!apiKey || !appId || !consumerId) {
+  console.error("Missing env APIDECK_API_KEY / APIDECK_APP_ID / APIDECK_CONSUMER_ID");
+  process.exit(2);
+}
+
+const logger = {
+  level: "info",
+  debug() {},
+  info() {},
+  warning() {},
+  error() {},
+};
+
+const booted = createGeneratedMCPServer({
+  logger,
+  codeMode: true,
+  getSDK: () => new ApideckMcpCore({ security: { apiKey }, appId, consumerId }),
+});
+
+const run = booted.server._registeredTools.apideck_run;
+
+const script = `
+const [consumers, connections] = await Promise.all([
+  apideck.vaultConsumersList({}),
+  apideck.vaultConnectionsList({}),
+]);
+return {
+  consumer_count: consumers.data?.length ?? 0,
+  connection_count: connections.data?.length ?? 0,
+  first_connection: connections.data?.[0]?.service_id ?? null,
+};
+`;
+
+const start = Date.now();
+const res = await run.handler(
+  { script },
+  { signal: AbortSignal.timeout(60_000) },
+);
+const ms = Date.now() - start;
+console.log(`apideck_run finished in ${ms}ms  isError=${res.isError ?? false}`);
+console.log(res.content[0].text);
+process.exit(res.isError ? 1 : 0);

--- a/test/gen-sandbox.test.mjs
+++ b/test/gen-sandbox.test.mjs
@@ -1,0 +1,284 @@
+/**
+ * Unit + integration tests for the code-sandbox meta-tools.
+ *
+ * Covers:
+ * - apideck_search returns filtered results
+ * - apideck_run executes a script, binds `apideck.*` methods to real
+ *   tool dispatches, captures console output, returns the final value
+ * - Error paths surface as isError with helpful text
+ * - Script timeout actually trips
+ * - Sandboxed code cannot reach Node globals (require, process, fs)
+ */
+
+import { createGeneratedMCPServer } from "../esm/src/gen/create-server.js";
+
+let failures = 0;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`);
+    failures++;
+  } else {
+    console.log(`  PASS: ${msg}`);
+  }
+};
+
+const logger = {
+  level: "info",
+  debug() {},
+  info() {},
+  warning() {},
+  error() {},
+};
+
+function captureFetch(body = '{"data":[{"id":"inv-1"},{"id":"inv-2"}]}') {
+  const calls = [];
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (input, opts = {}) => {
+    let url, hdrs;
+    if (input instanceof Request) {
+      url = input.url;
+      hdrs = input.headers;
+    } else {
+      url = String(input);
+      hdrs = opts.headers;
+    }
+    const h = hdrs instanceof Headers ? Object.fromEntries(hdrs.entries()) : { ...(hdrs ?? {}) };
+    calls.push({ url, headers: h });
+    return new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { calls, restore: () => (globalThis.fetch = orig) };
+}
+
+function bootCodeMode() {
+  return createGeneratedMCPServer({
+    logger,
+    codeMode: true,
+    getSDK: () => ({
+      _options: {
+        appId: "test-app",
+        consumerId: "test-consumer",
+        security: async () => ({ apiKey: "sk_test_sandbox" }),
+      },
+    }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Only apideck_search + apideck_run are registered in code mode
+// ---------------------------------------------------------------------------
+console.log("Test: codeMode exposes only apideck_search + apideck_run");
+{
+  const booted = bootCodeMode();
+  const toolNames = booted.tools.map((t) => t.name).sort();
+  assert(
+    toolNames.length === 2,
+    `exactly 2 tools registered (got ${toolNames.length}: ${toolNames.join(", ")})`,
+  );
+  assert(toolNames.includes("apideck_search"), "apideck_search present");
+  assert(toolNames.includes("apideck_run"), "apideck_run present");
+}
+
+// ---------------------------------------------------------------------------
+// 2. apideck_search filters by query
+// ---------------------------------------------------------------------------
+console.log("Test: apideck_search returns filtered endpoint list");
+{
+  const booted = bootCodeMode();
+  const search = booted.server._registeredTools.apideck_search;
+  const res = await search.handler(
+    { query: "invoices list" },
+    { signal: new AbortController().signal },
+  );
+  const payload = JSON.parse(res.content[0].text);
+  assert(payload.count > 0, `search returned ${payload.count} matches`);
+  assert(
+    payload.endpoints.some((e) => e.name === "accounting-invoices-list"),
+    "accounting-invoices-list in results",
+  );
+  assert(
+    payload.endpoints.every((e) => typeof e.method === "string"),
+    "each result has a camelCase method name",
+  );
+  assert(
+    payload.endpoints.find((e) => e.name === "accounting-invoices-list")?.method
+      === "accountingInvoicesList",
+    "name → method conversion is correct",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3. apideck_run: simple arithmetic returns
+// ---------------------------------------------------------------------------
+console.log("Test: apideck_run returns a script's computed value");
+{
+  const booted = bootCodeMode();
+  const run = booted.server._registeredTools.apideck_run;
+  const res = await run.handler(
+    { script: "return 1 + 2 + 3;" },
+    { signal: new AbortController().signal },
+  );
+  const payload = JSON.parse(res.content[0].text);
+  assert(payload.result === 6, `result === 6 (got ${payload.result})`);
+  assert(res.isError !== true, "success not flagged as error");
+}
+
+// ---------------------------------------------------------------------------
+// 4. apideck_run: calling a bound endpoint method issues real HTTP
+// ---------------------------------------------------------------------------
+console.log("Test: apideck_run binds `apideck.*` methods to real dispatches");
+{
+  const booted = bootCodeMode();
+  const run = booted.server._registeredTools.apideck_run;
+  const stub = captureFetch();
+  const res = await run.handler(
+    {
+      script: `
+        const resp = await apideck.accountingInvoicesList({ limit: 2 });
+        return { fetched: resp.data.length, ids: resp.data.map(d => d.id) };
+      `,
+    },
+    { signal: new AbortController().signal },
+  );
+  stub.restore();
+
+  const payload = JSON.parse(res.content[0].text);
+  assert(stub.calls.length === 1, "one upstream fetch was made");
+  assert(
+    stub.calls[0].headers["authorization"] === "Bearer sk_test_sandbox",
+    "auth header forwarded through sandbox",
+  );
+  assert(payload.result.fetched === 2, "script parsed the mocked response");
+  assert(
+    Array.isArray(payload.result.ids) && payload.result.ids[0] === "inv-1",
+    "script can transform response data",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 5. apideck_run: console.log output is captured and returned
+// ---------------------------------------------------------------------------
+console.log("Test: console.log output is captured in the result");
+{
+  const booted = bootCodeMode();
+  const run = booted.server._registeredTools.apideck_run;
+  const res = await run.handler(
+    { script: "console.log('hello', { foo: 42 }); return 'ok';" },
+    { signal: new AbortController().signal },
+  );
+  const payload = JSON.parse(res.content[0].text);
+  assert(Array.isArray(payload.logs), "logs array present");
+  assert(
+    payload.logs.some((l) => l.includes("hello") && l.includes("42")),
+    "log line captured with stringified args",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 6. apideck_run: thrown errors surface as isError
+// ---------------------------------------------------------------------------
+console.log("Test: apideck_run surfaces thrown errors as isError");
+{
+  const booted = bootCodeMode();
+  const run = booted.server._registeredTools.apideck_run;
+  const res = await run.handler(
+    { script: "throw new Error('boom');" },
+    { signal: new AbortController().signal },
+  );
+  const payload = JSON.parse(res.content[0].text);
+  assert(res.isError === true, "isError flag set");
+  assert(payload.error.includes("boom"), "error message preserved");
+}
+
+// ---------------------------------------------------------------------------
+// 7. apideck_run: timeouts trip
+// ---------------------------------------------------------------------------
+console.log("Test: script timeout aborts a long-running loop");
+{
+  const booted = bootCodeMode();
+  const run = booted.server._registeredTools.apideck_run;
+  const start = Date.now();
+  const res = await run.handler(
+    {
+      // Busy CPU loop — cannot be interrupted by ctrl.abort alone, so
+      // relies on vm's `timeout` option hitting first.
+      script: "while (true) {}",
+      timeout_ms: 1000,
+    },
+    { signal: new AbortController().signal },
+  );
+  const elapsed = Date.now() - start;
+  assert(res.isError === true, "timeout flagged as error");
+  assert(elapsed < 5000, `aborted within 5s (took ${elapsed}ms)`);
+}
+
+// ---------------------------------------------------------------------------
+// 8. Sandbox isolation: no access to Node globals like process/require
+// ---------------------------------------------------------------------------
+console.log("Test: sandbox hides Node globals (process, require)");
+{
+  const booted = bootCodeMode();
+  const run = booted.server._registeredTools.apideck_run;
+
+  const processRes = await run.handler(
+    { script: "return typeof process;" },
+    { signal: new AbortController().signal },
+  );
+  const processPayload = JSON.parse(processRes.content[0].text);
+  assert(
+    processPayload.result === "undefined",
+    `process is undefined in sandbox (got ${processPayload.result})`,
+  );
+
+  const requireRes = await run.handler(
+    { script: "return typeof require;" },
+    { signal: new AbortController().signal },
+  );
+  const requirePayload = JSON.parse(requireRes.content[0].text);
+  assert(
+    requirePayload.result === "undefined",
+    `require is undefined in sandbox (got ${requirePayload.result})`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 9. apideck_run: endpoint errors (isError=true) throw inside the sandbox
+// ---------------------------------------------------------------------------
+console.log("Test: endpoint errors throw inside the sandbox script");
+{
+  const booted = bootCodeMode();
+  const run = booted.server._registeredTools.apideck_run;
+  const orig = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response('{"error":"unauthorized"}', {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+  const res = await run.handler(
+    {
+      script: `
+        try {
+          await apideck.accountingInvoicesList({});
+          return 'no-throw';
+        } catch (e) {
+          return { caught: true, msg: e.message };
+        }
+      `,
+    },
+    { signal: new AbortController().signal },
+  );
+  globalThis.fetch = orig;
+  const payload = JSON.parse(res.content[0].text);
+  assert(payload.result.caught === true, "endpoint error caught by script");
+  assert(
+    typeof payload.result.msg === "string" && payload.result.msg.length > 0,
+    "error message carried through",
+  );
+}
+
+console.log(
+  `\n${failures === 0 ? "All sandbox tests passed" : `${failures} test(s) failed`}`,
+);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Phase 1 of the roadmap drawn from the [*building agents that reach production systems with MCP*](https://claude.com/blog/building-agents-that-reach-production-systems-with-mcp) patterns — a thin tool surface that agents drive by writing code, instead of materialising 330 tool definitions into context.

## New query knobs on the hosted endpoint

| Param | Effect |
|---|---|
| *(default)* | custom generator, dynamic-mode (4 meta-tools + 330 tool catalog) |
| `?engine=legacy` | fall back to the Speakeasy-generated server |
| `?mode=code` | register only `apideck_search` + `apideck_run` (this PR) |

## What `?mode=code` gives agents

- `apideck_search(query?: string)` — browse 330 endpoints as `{ name, method, description, scopes }`, filter by space-separated terms
- `apideck_run(script: string, timeout_ms?: number)` — run an async JS snippet inside a vm.Context with `apideck.accountingInvoicesList({…})`, `apideck.vaultConnectionsList({…})`, etc. bound as callables. Only the script's final return value reaches context.

Example one-liner:

```js
const [invoices, bills] = await Promise.all([
  apideck.accountingInvoicesList({ limit: 100 }),
  apideck.accountingBillsList({ limit: 100 }),
]);
return {
  receivable: invoices.data.reduce((s, i) => s + i.balance, 0),
  payable:    bills.data.reduce((s, b) => s + b.balance, 0),
};
```

Two endpoints, one round-trip, two numbers back to the model instead of ~200KB of raw JSON.

## Why

Per the blog:
> If your service requires hundreds of distinct operations, such as Cloudflare, AWS, or Kubernetes, an intent-grouped toolset likely won't cover it. Instead, expose a thin tool surface that accepts code.

Cloudflare uses 2 tools for 2,500 endpoints; we do 2 for 330.

## Tests (all green)

24 new assertions in `test/gen-sandbox.test.mjs`:
- only 2 tools registered in code mode
- search filters by query, name → method mapping correct
- scripts return computed values
- `apideck.*` dispatches carry the `Authorization: Bearer` header
- `console.log` output captured
- thrown errors flagged `isError`
- busy-loop scripts hit the 1s timeout (vm.Script `timeout` option)
- sandbox hides Node globals (`process`, `require` both undefined)
- endpoint errors throw inside the script so agents can `try/catch`

Plus a live probe (`test/gen-sandbox-live.mjs`) run against `unify.apideck.com`:

```
apideck_run finished in 450ms  isError=false
{ "result": { "consumer_count": 2, "connection_count": 10, "first_connection": "gmail" } }
```

## Not in this PR

- Hardened isolation — `vm.Context` is defence-in-depth, not a true sandbox. Same threat model as our hosted tool path (caller authenticates with their own Apideck API key). Swap to `worker_threads` or Firecracker if the threat model changes.
- Intent-grouped workflow tools (Phase 3 of the plan)
- URL-mode elicitation for Vault OAuth (Phase 2)

## Rollout

Gated behind `?mode=code`. No behaviour change for existing traffic.
