### PR TITLE
Add Aikido MCP to project-scope .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,23 @@
+{
+  "$comment": "Project-scope MCP servers for contributors using Claude Code / Cursor / Windsurf. Separate from the user-facing `mcp.json` (Open Plugins manifest).",
+  "mcpServers": {
+    "aikido": {
+      "$comment": "Security scanner for AI-generated code. Set AIKIDO_API_KEY in your shell; get a key at https://app.aikido.dev. Docs: https://help.aikido.dev/ai-and-dev-tools/aikido-mcp",
+      "command": "npx",
+      "args": ["-y", "@aikidosec/mcp"],
+      "env": {
+        "AIKIDO_API_KEY": "${AIKIDO_API_KEY}"
+      }
+    },
+    "apideck-local": {
+      "$comment": "The MCP server this repo ships. Handy for exercising your own changes from inside an agent session.",
+      "command": "node",
+      "args": ["bin/mcp-server.js", "start", "--transport", "stdio"],
+      "env": {
+        "APIDECK_API_KEY": "${APIDECK_API_KEY}",
+        "APIDECK_APP_ID": "${APIDECK_APP_ID}",
+        "APIDECK_CONSUMER_ID": "${APIDECK_CONSUMER_ID}"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -247,6 +247,17 @@ npx tsx test/mcp-server.test.ts
 MCP_URL=https://mcp.apideck.dev/mcp npx tsx test/mcp-server.test.ts
 ```
 
+## Contributing
+
+The repo ships a `.mcp.json` with two project-scope MCP servers that Claude Code / Cursor / Windsurf pick up automatically:
+
+| Server | Purpose |
+|---|---|
+| `aikido` | Scans AI-generated code for vulnerabilities + hardcoded secrets. Needs `AIKIDO_API_KEY` in your shell — [get one](https://app.aikido.dev). |
+| `apideck-local` | Runs *this* server from the local build (`bin/mcp-server.js start`) so you can exercise your own changes through an agent. Uses the standard `APIDECK_*` env vars. |
+
+No credentials are committed — each entry reads its token from the environment.
+
 ## License
 
 MIT


### PR DESCRIPTION
[Aikido's MCP server](https://help.aikido.dev/ai-and-dev-tools/aikido-mcp) scans AI-generated code for vulnerabilities and hardcoded secrets in real time, inside the agent session that produced the code. Adding it to this repo's project-scope `.mcp.json` means any contributor using Claude Code / Cursor / Windsurf / OpenCode gets the scanner auto-loaded when they work here.

## Two servers in `.mcp.json`

| Server | npm | Purpose |
|---|---|---|
| `aikido` | [`@aikidosec/mcp`](https://www.npmjs.com/package/@aikidosec/mcp) | Vulnerability + secret scanning on every AI-generated snippet before it's committed |
| `apideck-local` | *(runs `bin/mcp-server.js` from the local build)* | Exercise this repo's MCP server from inside an agent session without shipping a new version |

Both read their tokens from the contributor's shell env — no credentials committed:

```bash
export AIKIDO_API_KEY=...   # from app.aikido.dev
export APIDECK_API_KEY=...  # standard Apideck key
export APIDECK_APP_ID=...
export APIDECK_CONSUMER_ID=...
```

## What this does not do

- **Doesn't affect the published server.** The hosted endpoint at `mcp.apideck.dev/mcp` and the `@apideck/mcp` npm package are unchanged — this is dev tooling.
- **Doesn't install Aikido as a GitHub App / repo-level scanner.** If you want continuous repo scans (pushes, PRs, secret rotation, SCA), that's a separate onboarding at [app.aikido.dev](https://app.aikido.dev) — product-level, not something that lives in the repo.
