### PR TITLE
Phase 2: URL elicitation for Vault OAuth on connection failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
           node test/gen-server.test.mjs
           node test/gen-extras.test.mjs
           node test/gen-handler-e2e.test.mjs
+          node test/gen-elicitation.test.mjs
 
   deploy:
     needs: build-and-test

--- a/src/gen/elicitation.ts
+++ b/src/gen/elicitation.ts
@@ -1,0 +1,179 @@
+/**
+ * Detect Vault connection issues in upstream Apideck responses and
+ * hand the user a consent URL via MCP's URL-mode elicitation.
+ *
+ * When Apideck returns a connector error that means "the consumer hasn't
+ * connected this service yet" or "their token has expired", we:
+ *   1. Mint a one-time Vault session URL via /vault/sessions
+ *   2. Throw UrlElicitationRequiredError so the MCP client (Claude Code
+ *      today; others following) can render a "Connect your account" button
+ *   3. Fall back to a descriptive text error on clients that don't yet
+ *      handle URL elicitation — the LLM can still surface the URL
+ */
+
+import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
+import { randomUUID } from "node:crypto";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+const VAULT_SESSIONS_ENDPOINT = "https://unify.apideck.com/vault/sessions";
+
+/** Canonical markers for "the consumer needs to (re-)authorise a connection". */
+const CONNECTION_ISSUE_MARKERS = [
+  "re-authorize the connection",
+  "re-authorise the connection",
+  "connection is missing",
+  "no active connection",
+  "connection not found",
+  "connection is disabled",
+  "invalid grant",
+  "unauthorized_client",
+  "persistuseruid hook",
+];
+
+export interface ConnectionIssue {
+  status: number;
+  /** Unified API the failing call targeted, e.g. "accounting". */
+  unifiedApi?: string | undefined;
+  /** Service ID of the specific connector, e.g. "xero". */
+  serviceId?: string | undefined;
+  /** Short human-readable explanation lifted from the upstream response. */
+  summary: string;
+}
+
+/**
+ * Inspect an Apideck response body to decide whether the failure is a
+ * connection-level issue (consumer needs to auth a connector) rather
+ * than a bad request or a real server error.
+ */
+export function detectConnectionIssue(
+  status: number,
+  body: string,
+): ConnectionIssue | null {
+  if (status < 400) return null;
+
+  const bodyLower = body.toLowerCase();
+  const hasMarker = CONNECTION_ISSUE_MARKERS.some((m) => bodyLower.includes(m));
+  if (!hasMarker) return null;
+
+  let unifiedApi: string | undefined;
+  let serviceId: string | undefined;
+  let summary = body.slice(0, 200);
+
+  try {
+    const parsed = JSON.parse(body) as {
+      message?: string;
+      detail?: {
+        context?: { connector?: string; unified_api?: string };
+        error?: { detail?: { errors?: Array<{ message?: string }> } };
+      };
+    };
+    const ctx = parsed.detail?.context;
+    if (ctx?.unified_api) unifiedApi = ctx.unified_api;
+    if (ctx?.connector) serviceId = ctx.connector.toLowerCase();
+    const inner = parsed.detail?.error?.detail?.errors?.[0]?.message;
+    summary = inner ?? parsed.message ?? summary;
+  } catch {
+    // Non-JSON body — keep the truncated text summary.
+  }
+
+  return { status, unifiedApi, serviceId, summary };
+}
+
+export interface VaultSessionContext {
+  /** Resolved API key (already extracted from lazy security). */
+  apiKey: string;
+  appId?: string | undefined;
+  consumerId?: string | undefined;
+  signal?: AbortSignal | undefined;
+}
+
+/**
+ * POST /vault/sessions to get a one-time-use consent URL. Returns null
+ * if we can't mint one (e.g., no consumer_id configured) — the caller
+ * then falls back to a plain text error.
+ */
+export async function mintVaultSessionUrl(
+  ctx: VaultSessionContext,
+): Promise<string | null> {
+  if (!ctx.apiKey || !ctx.consumerId) return null;
+
+  const headers = new Headers({
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${ctx.apiKey}`,
+    "x-apideck-consumer-id": ctx.consumerId,
+  });
+  if (ctx.appId) headers.set("x-apideck-app-id", ctx.appId);
+
+  let resp: Response;
+  try {
+    resp = await fetch(VAULT_SESSIONS_ENDPOINT, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({}),
+      signal: ctx.signal ?? null,
+    });
+  } catch {
+    return null;
+  }
+  if (!resp.ok) return null;
+
+  try {
+    const body = await resp.json() as { data?: { session_uri?: string } };
+    return body.data?.session_uri ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build either an MCP UrlElicitationRequiredError (for clients that
+ * support URL elicitation) or a descriptive CallToolResult fallback.
+ * Callers decide which to throw/return based on negotiated client
+ * capabilities; by default we throw the elicitation — the SDK emits
+ * a well-formed JSON-RPC error that clients without URL support can
+ * still surface as text.
+ */
+export function buildConnectionElicitation(
+  issue: ConnectionIssue,
+  sessionUrl: string,
+): UrlElicitationRequiredError {
+  const target = issue.serviceId
+    ? `your ${issue.serviceId}${issue.unifiedApi ? " " + issue.unifiedApi : ""} connection`
+    : "the required connection";
+  const message =
+    `Apideck couldn't reach ${target}: ${issue.summary}\n` +
+    `Open the link below to connect or re-authorise, then retry the tool call.`;
+  return new UrlElicitationRequiredError(
+    [
+      {
+        mode: "url",
+        message,
+        url: sessionUrl,
+        elicitationId: randomUUID(),
+      },
+    ],
+    message,
+  );
+}
+
+/** Plain-text fallback for clients that don't support URL elicitation. */
+export function connectionIssueFallback(
+  issue: ConnectionIssue,
+  sessionUrl: string | null,
+): CallToolResult {
+  const parts = [
+    `Apideck connection issue (HTTP ${issue.status}).`,
+    issue.unifiedApi || issue.serviceId
+      ? `Target: ${issue.unifiedApi ?? "?"}${issue.serviceId ? "/" + issue.serviceId : ""}`
+      : undefined,
+    `Reason: ${issue.summary}`,
+    sessionUrl
+      ? `Complete Vault consent: ${sessionUrl}`
+      : "Ask the end-user to connect the service in Apideck Vault, then retry.",
+  ].filter(Boolean);
+  return {
+    content: [{ type: "text", text: parts.join("\n") }],
+    isError: true,
+  };
+}

--- a/src/gen/runtime.ts
+++ b/src/gen/runtime.ts
@@ -15,7 +15,14 @@
  */
 
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
 import type { ApideckMcpCore } from "../core.js";
+import {
+  buildConnectionElicitation,
+  connectionIssueFallback,
+  detectConnectionIssue,
+  mintVaultSessionUrl,
+} from "./elicitation.js";
 
 const BASE_URL = "https://unify.apideck.com";
 const RETRY_STATUS = new Set([408, 500, 502, 503, 504]);
@@ -113,17 +120,37 @@ export async function callApideck(
   const qs = query.toString();
   const url = `${BASE_URL}${path}${qs ? `?${qs}` : ""}`;
 
+  // Non-throwing context carrier so dispatch can mint a Vault session URL
+  // when it sees a connection-level failure in the response body.
+  const elicitCtx = {
+    apiKey,
+    appId: opts.appId,
+    consumerId: opts.consumerId,
+    signal: desc.signal,
+  };
+
   return withRetry(async () =>
     dispatch(url, {
       method: desc.method,
       headers,
       body,
       signal: desc.signal ?? null,
-    })
+    }, elicitCtx)
   );
 }
 
-async function dispatch(url: string, init: RequestInit): Promise<CallToolResult> {
+interface ElicitCtx {
+  apiKey: string | undefined;
+  appId: string | undefined;
+  consumerId: string | undefined;
+  signal: AbortSignal | undefined;
+}
+
+async function dispatch(
+  url: string,
+  init: RequestInit,
+  elicitCtx: ElicitCtx,
+): Promise<CallToolResult> {
   let resp: Response;
   try {
     resp = await fetch(url, init);
@@ -151,6 +178,27 @@ async function dispatch(url: string, init: RequestInit): Promise<CallToolResult>
   }
 
   const text = await resp.text();
+
+  // Detect Vault connection issues and hand the user a consent URL via
+  // MCP URL elicitation. Non-connection errors fall through as plain text.
+  if (!resp.ok) {
+    const issue = detectConnectionIssue(resp.status, text);
+    if (issue) {
+      const sessionUrl = elicitCtx.apiKey
+        ? await mintVaultSessionUrl({
+          apiKey: elicitCtx.apiKey,
+          appId: elicitCtx.appId,
+          consumerId: elicitCtx.consumerId,
+          signal: elicitCtx.signal,
+        })
+        : null;
+      if (sessionUrl) {
+        throw buildConnectionElicitation(issue, sessionUrl);
+      }
+      return connectionIssueFallback(issue, sessionUrl);
+    }
+  }
+
   return { content: [{ type: "text", text }], isError: !resp.ok };
 }
 
@@ -177,6 +225,10 @@ async function withRetry(
       delay = Math.min(delay * opts.factor, opts.maxMs);
     }
   }
+  // URL elicitations must reach the MCP client as a JSON-RPC error with
+  // the URL_ELICITATION_REQUIRED code — toolError would flatten them to
+  // a plain-text tool result and drop the URL.
+  if (lastError instanceof UrlElicitationRequiredError) throw lastError;
   const msg = lastError instanceof Error ? lastError.message : String(lastError);
   return toolError(msg);
 }

--- a/src/mcp-server/tools.ts
+++ b/src/mcp-server/tools.ts
@@ -475,6 +475,17 @@ export function registerDynamicTools(
       captureToolCall(analytics, sdk, args.name, "dynamic", start, result);
       return result;
     } catch (error) {
+      // MCP protocol errors (e.g. UrlElicitationRequiredError, used to hand
+      // the user a consent URL for a missing Vault connection) must reach
+      // the client as first-class JSON-RPC errors — wrapping them in a
+      // text tool result would drop the elicitation payload.
+      if (error instanceof Error && error.name === "McpError") {
+        captureToolCall(analytics, sdk, args.name, "dynamic", start, {
+          content: [{ type: "text", text: error.message }],
+          isError: true,
+        });
+        throw error;
+      }
       const message = error instanceof Error ? error.message : String(error);
       const errorResult: CallToolResult = {
         content: [{

--- a/test/gen-elicitation.test.mjs
+++ b/test/gen-elicitation.test.mjs
@@ -1,0 +1,300 @@
+/**
+ * Tests for Vault OAuth elicitation on connection failures.
+ *
+ * Covers:
+ * - detectConnectionIssue recognises Apideck's canonical markers
+ * - Benign 4xx responses don't trigger elicitation
+ * - mintVaultSessionUrl hits /vault/sessions with the right headers
+ * - A connection failure results in a thrown UrlElicitationRequiredError
+ *   carrying the Vault session URL
+ * - Plain-text fallback when session minting fails
+ * - Non-connection 4xx responses keep the existing behaviour (text result)
+ */
+
+import { UrlElicitationRequiredError } from "../node_modules/@modelcontextprotocol/sdk/dist/esm/types.js";
+import {
+  buildConnectionElicitation,
+  connectionIssueFallback,
+  detectConnectionIssue,
+  mintVaultSessionUrl,
+} from "../esm/src/gen/elicitation.js";
+import { createGeneratedMCPServer } from "../esm/src/gen/create-server.js";
+
+let failures = 0;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`);
+    failures++;
+  } else {
+    console.log(`  PASS: ${msg}`);
+  }
+};
+
+const logger = {
+  level: "info",
+  debug() {},
+  info() {},
+  warning() {},
+  error() {},
+};
+
+const CONNECTION_ERROR_BODY = JSON.stringify({
+  status_code: 400,
+  error: "Bad Request",
+  type_name: "ConnectorExecutionError",
+  message: "Odoo Connector Returned Error",
+  detail: {
+    context: { connector: "odoo", unified_api: "accounting" },
+    error: {
+      typeName: "ThrowableHookError",
+      detail: {
+        errors: [{
+          type: "BadRequest",
+          message:
+            "Odoo connection is missing a valid userUID. This usually means the persistUserUID hook did not run successfully. Please re-authorize the connection to resolve this.",
+        }],
+      },
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// 1. detectConnectionIssue recognises the Apideck error envelope
+// ---------------------------------------------------------------------------
+console.log("Test: detectConnectionIssue extracts connector + unified_api");
+{
+  const issue = detectConnectionIssue(400, CONNECTION_ERROR_BODY);
+  assert(issue !== null, "issue detected");
+  if (issue) {
+    assert(issue.status === 400, "status preserved");
+    assert(issue.serviceId === "odoo", `serviceId = odoo (got ${issue.serviceId})`);
+    assert(issue.unifiedApi === "accounting", `unifiedApi = accounting (got ${issue.unifiedApi})`);
+    assert(
+      issue.summary.toLowerCase().includes("re-authorize"),
+      "summary surfaces the actionable reason",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Benign 4xx (e.g. validation error) is NOT flagged
+// ---------------------------------------------------------------------------
+console.log("Test: generic 4xx is not flagged as connection issue");
+{
+  const issue = detectConnectionIssue(
+    422,
+    JSON.stringify({ message: "Required field missing: customer_id" }),
+  );
+  assert(issue === null, "non-connection error ignored");
+}
+
+// ---------------------------------------------------------------------------
+// 3. Non-JSON connection error still detected via substring
+// ---------------------------------------------------------------------------
+console.log("Test: non-JSON body containing canonical marker still detected");
+{
+  const issue = detectConnectionIssue(
+    503,
+    "upstream: Connection not found for this consumer",
+  );
+  assert(issue !== null, "detected via substring");
+  assert(issue?.unifiedApi === undefined, "no service metadata when body is non-JSON");
+}
+
+// ---------------------------------------------------------------------------
+// 4. mintVaultSessionUrl calls /vault/sessions with correct headers/body
+// ---------------------------------------------------------------------------
+console.log("Test: mintVaultSessionUrl posts to /vault/sessions");
+{
+  const calls = [];
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (url, opts = {}) => {
+    const hdrs = opts.headers instanceof Headers
+      ? Object.fromEntries(opts.headers.entries())
+      : { ...opts.headers };
+    calls.push({ url: String(url), method: opts.method, headers: hdrs, body: opts.body });
+    return new Response(
+      JSON.stringify({ data: { session_uri: "https://vault.apideck.com/session/abc" } }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+  const url = await mintVaultSessionUrl({
+    apiKey: "sk_test_elicit",
+    appId: "app-xyz",
+    consumerId: "consumer-xyz",
+  });
+  globalThis.fetch = orig;
+
+  assert(url === "https://vault.apideck.com/session/abc", "session URL returned");
+  assert(calls[0]?.url === "https://unify.apideck.com/vault/sessions", "hit /vault/sessions");
+  assert(calls[0]?.method === "POST", "POST method");
+  assert(
+    calls[0]?.headers["authorization"] === "Bearer sk_test_elicit",
+    "Bearer auth sent",
+  );
+  assert(
+    calls[0]?.headers["x-apideck-consumer-id"] === "consumer-xyz",
+    "consumer-id sent",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Missing consumer_id: mintVaultSessionUrl returns null, no fetch call
+// ---------------------------------------------------------------------------
+console.log("Test: mintVaultSessionUrl bails when consumer_id is missing");
+{
+  let called = false;
+  const orig = globalThis.fetch;
+  globalThis.fetch = async () => {
+    called = true;
+    return new Response("{}", { status: 200 });
+  };
+  const url = await mintVaultSessionUrl({
+    apiKey: "sk_test",
+    appId: "app",
+    consumerId: undefined,
+  });
+  globalThis.fetch = orig;
+  assert(url === null, "returned null");
+  assert(!called, "did not call Vault");
+}
+
+// ---------------------------------------------------------------------------
+// 6. buildConnectionElicitation produces a well-formed error
+// ---------------------------------------------------------------------------
+console.log("Test: buildConnectionElicitation shapes a URL elicitation");
+{
+  const err = buildConnectionElicitation(
+    { status: 400, serviceId: "xero", unifiedApi: "accounting", summary: "re-auth needed" },
+    "https://vault.apideck.com/session/xyz",
+  );
+  assert(err instanceof UrlElicitationRequiredError, "is UrlElicitationRequiredError");
+  assert(err.elicitations.length === 1, "one elicitation");
+  const e = err.elicitations[0];
+  assert(e.mode === "url", "mode=url");
+  assert(e.url === "https://vault.apideck.com/session/xyz", "url carries session URL");
+  assert(typeof e.elicitationId === "string" && e.elicitationId.length > 0, "elicitationId set");
+  assert(
+    e.message.toLowerCase().includes("xero"),
+    "message references the failing service",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 7. End-to-end via the real tool: connection error → elicitation thrown
+// ---------------------------------------------------------------------------
+console.log("Test: e2e — connection error from Apideck triggers elicitation");
+{
+  const booted = createGeneratedMCPServer({
+    logger,
+    dynamic: true,
+    getSDK: () => ({
+      _options: {
+        appId: "app",
+        consumerId: "consumer",
+        security: async () => ({ apiKey: "sk_test_e2e" }),
+      },
+    }),
+  });
+
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (url.includes("/vault/sessions")) {
+      return new Response(
+        JSON.stringify({ data: { session_uri: "https://vault.apideck.com/session/e2e" } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    // The actual tool call: return the connection error shape
+    return new Response(CONNECTION_ERROR_BODY, {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  let thrown;
+  try {
+    await booted.server._registeredTools.execute_tool.handler(
+      {
+        name: "accounting-invoices-list",
+        arguments: { request: { limit: 1 } },
+      },
+      { signal: new AbortController().signal },
+    );
+  } catch (err) {
+    thrown = err;
+  }
+  globalThis.fetch = orig;
+
+  assert(thrown instanceof UrlElicitationRequiredError, "UrlElicitationRequiredError thrown");
+  assert(
+    thrown?.elicitations?.[0]?.url === "https://vault.apideck.com/session/e2e",
+    "session URL from minted response",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 8. Fallback path: if Vault session minting fails, return text result
+// ---------------------------------------------------------------------------
+console.log("Test: fallback text result when session minting fails");
+{
+  const result = connectionIssueFallback(
+    { status: 401, serviceId: "xero", unifiedApi: "accounting", summary: "token expired" },
+    null,
+  );
+  assert(result.isError === true, "isError set");
+  const text = result.content[0].text;
+  assert(text.includes("accounting/xero"), "target referenced");
+  assert(text.includes("token expired"), "reason carried through");
+}
+
+// ---------------------------------------------------------------------------
+// 9. Non-connection errors pass through unchanged (no elicitation fired)
+// ---------------------------------------------------------------------------
+console.log("Test: non-connection 4xx returns plain text result, no elicitation");
+{
+  const booted = createGeneratedMCPServer({
+    logger,
+    dynamic: true,
+    getSDK: () => ({
+      _options: {
+        appId: "app",
+        consumerId: "consumer",
+        security: async () => ({ apiKey: "sk_test" }),
+      },
+    }),
+  });
+
+  const orig = globalThis.fetch;
+  let vaultCalled = false;
+  globalThis.fetch = async (input) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (url.includes("/vault/sessions")) vaultCalled = true;
+    return new Response(
+      JSON.stringify({ message: "Required field missing: customer_id" }),
+      { status: 422, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const res = await booted.server._registeredTools.execute_tool.handler(
+    {
+      name: "accounting-invoices-list",
+      arguments: { request: { limit: 1 } },
+    },
+    { signal: new AbortController().signal },
+  );
+  globalThis.fetch = orig;
+
+  assert(res.isError === true, "isError=true on 422");
+  assert(
+    res.content[0].text.includes("customer_id"),
+    "original error text passes through",
+  );
+  assert(!vaultCalled, "Vault session URL was NOT minted for a validation error");
+}
+
+console.log(
+  `\n${failures === 0 ? "All elicitation tests passed" : `${failures} test(s) failed`}`,
+);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Phase 2 of the roadmap from the [*building agents that reach production systems with MCP*](https://claude.com/blog/building-agents-that-reach-production-systems-with-mcp) post. Quoting the relevant bit:

> URL mode hands the user to a browser — use it to complete downstream OAuth, take a payment, or collect any credential that should never transit the MCP client.

Today, when an agent hits a tool call for a consumer who hasn't connected that service (or whose token has expired), the tool just errors out — the agent has no path back to a working state without leaving the chat. This PR intercepts that case and hands the user a Vault consent URL via MCP's URL-mode elicitation.

## Flow

1. Tool call executes as usual
2. Apideck responds with a connector error (e.g. `ConnectorExecutionError` + "re-authorize the connection")
3. Runtime detects the pattern, POSTs `/vault/sessions` to mint a one-time consent URL
4. Throws `UrlElicitationRequiredError` carrying `{ mode: "url", url: sessionUri, message: "…" }`
5. MCP clients with URL elicitation support (Claude Code today, more in progress) render a "Connect your account" button
6. User clicks, completes OAuth in Apideck Vault, comes back, agent retries the tool
7. Clients without URL elicitation support fall through to a text tool result that still includes the URL — the LLM can paste it back to the user

## Files

| | |
|---|---|
| `src/gen/elicitation.ts` (new) | detection + minting + error construction |
| `src/gen/runtime.ts` | post-fetch interceptor; withRetry re-throws protocol errors instead of flattening them |
| `src/mcp-server/tools.ts` | `execute_tool`'s try/catch now lets `McpError` subclasses propagate; generic failures still text-wrapped |
| `test/gen-elicitation.test.mjs` (new, 22 assertions) | detection markers, session minting, elicitation shape, e2e through execute_tool |

## Detection markers

Positive — response flagged:
- `"re-authorize the connection"`
- `"connection is missing"`
- `"no active connection"`
- `"connection not found"`
- `"persistUserUID hook"`
- `"invalid grant"` / `"unauthorized_client"`

Negative — untouched:
- Generic 422 validation errors (e.g. "Required field missing")
- 5xx server errors (retried by existing retry path, not elicited)
- 2xx responses

## Rollout

No query param needed — this is an enhancement to the existing error path, so every tool call gets it automatically. Rollback is a simple revert since the detection is narrow (specific strings) and the fallback is the old behaviour.

## Not in this PR

- Per-service consent URLs (Vault session URL currently covers all services; narrowing it to just the failing one would be a UX improvement)
- Form-mode elicitation for missing required parameters (Phase 2b)
- Re-invocation hints (some clients will auto-retry after elicitation; others won't — out of scope here)
