### PR TITLE
Plumb Claro-enhanced OpenAPI spec into the generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ docs/superpowers/
 *.pem
 # Local-only drafts (blog posts, notes)
 /drafts/
+# Claro runtime artefacts — specs/<id>/enhanced-openapi.yml is tracked,
+# the rest of the working directory is not.
+/specs/*/tmp/
+/specs/*/cached-responses.json
+/specs/*/overlays/
+/specs/*/registry.json

--- a/gen/node/generate.mjs
+++ b/gen/node/generate.mjs
@@ -15,12 +15,37 @@ import yaml from "js-yaml";
 import { jsonSchemaToZod } from "json-schema-to-zod";
 
 const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
-const SPEC_FILE = path.join(REPO, "speakeasy-spec.yml");
 const OVERLAY_FILE = path.join(REPO, "mcp-overlay.yaml");
 const OUT_DIR = path.join(REPO, "src", "gen");
 
-const spec = yaml.load(fs.readFileSync(SPEC_FILE, "utf8"));
+/**
+ * Prefer Claro's enhanced OpenAPI spec when present. Claro
+ * (github.com/apideck-io/claro) runs LLMs over the raw spec to produce
+ * richer operation summaries / parameter descriptions, then emits the
+ * enhanced spec as a YAML or JSON file. Our generator reads those
+ * descriptions verbatim and layers the MCP-specific scaffolding
+ * (side-effects, usage hints, connection context) on top.
+ *
+ * Fallback to the raw Speakeasy spec keeps the generator runnable
+ * before Claro has been run at least once.
+ */
+const SPEC_CANDIDATES = [
+  path.join(REPO, "specs", "apideck-mcp", "enhanced-openapi.yml"),
+  path.join(REPO, "specs", "apideck-mcp", "enhanced-openapi.yaml"),
+  path.join(REPO, "specs", "apideck-mcp", "enhanced-openapi.json"),
+  path.join(REPO, "speakeasy-spec.yml"),
+];
+const SPEC_FILE = SPEC_CANDIDATES.find((p) => fs.existsSync(p));
+if (!SPEC_FILE) {
+  throw new Error(
+    `No OpenAPI spec found. Expected one of:\n  ${SPEC_CANDIDATES.join("\n  ")}`,
+  );
+}
+const specSource = SPEC_FILE.endsWith(".json") ? "json" : "yaml";
+const specText = fs.readFileSync(SPEC_FILE, "utf8");
+const spec = specSource === "json" ? JSON.parse(specText) : yaml.load(specText);
 const overlay = yaml.load(fs.readFileSync(OVERLAY_FILE, "utf8"));
+console.error(`[generate] spec: ${path.relative(REPO, SPEC_FILE)}`);
 
 // ----------------------------------------------------------------------------
 // Overlay: disabled paths

--- a/gen/run-claro.sh
+++ b/gen/run-claro.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Run Claro (github.com/apideck-io/claro — private) to produce an
+# LLM-enhanced OpenAPI spec. Output goes to
+# specs/apideck-mcp/enhanced-openapi.yml and is consumed by
+# gen/node/generate.mjs.
+#
+# Requirements:
+#   - gh CLI authenticated with access to apideck-io/claro
+#   - pnpm installed
+#   - OPENAI_API_KEY or ANTHROPIC_API_KEY in the environment
+#
+# The script clones Claro into a gitignored sibling directory, installs,
+# builds, and runs `enhance` against the raw Apideck spec. Rerun whenever
+# the upstream spec changes.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLARO_DIR="${CLARO_DIR:-/tmp/apideck-claro}"
+SPEC_URL="${SPEC_URL:-https://ci-spec-unify.s3.eu-central-1.amazonaws.com/speakeasy-spec.yml}"
+SPEC_ID="${SPEC_ID:-apideck-mcp}"
+OUT_DIR="$REPO_ROOT/specs/$SPEC_ID"
+
+echo "[claro] repo root: $REPO_ROOT"
+echo "[claro] spec source: $SPEC_URL"
+echo "[claro] claro checkout: $CLARO_DIR"
+
+if [ ! -d "$CLARO_DIR" ]; then
+  echo "[claro] cloning apideck-io/claro …"
+  gh repo clone apideck-io/claro "$CLARO_DIR"
+fi
+
+cd "$CLARO_DIR"
+echo "[claro] pnpm install"
+pnpm install --frozen-lockfile || pnpm install
+
+echo "[claro] enhance --specId $SPEC_ID --format yaml --cacheResponses"
+pnpm run enhance \
+  --specId "$SPEC_ID" \
+  --incomingSpecUrl "$SPEC_URL" \
+  --format yaml \
+  --cacheResponses
+
+ENHANCED="$CLARO_DIR/specs/$SPEC_ID/openapi.yml"
+if [ ! -f "$ENHANCED" ]; then
+  echo "[claro] ERROR: expected $ENHANCED to exist after enhance" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+cp "$ENHANCED" "$OUT_DIR/enhanced-openapi.yml"
+echo "[claro] wrote $OUT_DIR/enhanced-openapi.yml ($(wc -c < "$OUT_DIR/enhanced-openapi.yml") bytes)"
+echo "[claro] next: cd $REPO_ROOT && node gen/node/generate.mjs"

--- a/gen/run-claro.sh
+++ b/gen/run-claro.sh
@@ -28,11 +28,23 @@ echo "[claro] claro checkout: $CLARO_DIR"
 if [ ! -d "$CLARO_DIR" ]; then
   echo "[claro] cloning apideck-io/claro …"
   gh repo clone apideck-io/claro "$CLARO_DIR"
+else
+  echo "[claro] pulling latest from origin/main …"
+  git -C "$CLARO_DIR" fetch origin main
+  git -C "$CLARO_DIR" checkout main
+  git -C "$CLARO_DIR" reset --hard origin/main
 fi
 
 cd "$CLARO_DIR"
 echo "[claro] pnpm install"
 pnpm install --frozen-lockfile || pnpm install
+# sqlite3 ships as a native module; pnpm doesn't run its install
+# script by default, so prebuild-install never fires. Trigger it
+# manually when the native artifact is missing.
+if ! [ -f node_modules/.pnpm/sqlite3@*/node_modules/sqlite3/build/Release/node_sqlite3.node ] 2>/dev/null; then
+  echo "[claro] building sqlite3 native module"
+  (cd node_modules/.pnpm/sqlite3@*/node_modules/sqlite3 && npm run install >/dev/null 2>&1) || true
+fi
 echo "[claro] pnpm run build"
 pnpm run build
 

--- a/gen/run-claro.sh
+++ b/gen/run-claro.sh
@@ -33,11 +33,65 @@ fi
 cd "$CLARO_DIR"
 echo "[claro] pnpm install"
 pnpm install --frozen-lockfile || pnpm install
+echo "[claro] pnpm run build"
+pnpm run build
 
-echo "[claro] enhance --specId $SPEC_ID --format yaml --cacheResponses"
+# Pick the provider based on which key the caller has exported. Defaults
+# point at the latest-generation models available as of April 2026;
+# override the MODEL env vars if you want to pin something older or try
+# a smaller/cheaper variant.
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  PROVIDER="${PROVIDER:-anthropic}"
+  : "${ANTHROPIC_MODEL:=claude-sonnet-4-6}"
+  export ANTHROPIC_API_KEY ANTHROPIC_MODEL
+elif [ -n "${OPENAI_API_KEY:-}" ]; then
+  PROVIDER="${PROVIDER:-openai}"
+  : "${OPENAI_MODEL:=gpt-4.1-mini}"
+  export OPENAI_API_KEY OPENAI_MODEL
+else
+  echo "[claro] ERROR: set ANTHROPIC_API_KEY or OPENAI_API_KEY in the environment" >&2
+  exit 2
+fi
+
+# Pre-process: fetch the upstream spec and ensure every operation has
+# a `description` (fall back to `summary`). Claro's enhancement graph
+# requires content.description to be populated; Apideck's spec has
+# summary-only operations that would otherwise fail mid-pipeline.
+PREPPED_SPEC="$CLARO_DIR/tmp/apideck-mcp-input.yml"
+mkdir -p "$(dirname "$PREPPED_SPEC")"
+echo "[claro] fetching + normalising spec → $PREPPED_SPEC"
+node --input-type=module -e "
+  import https from 'node:https';
+  import fs from 'node:fs';
+  import yaml from '$CLARO_DIR/node_modules/js-yaml/dist/js-yaml.mjs';
+  const url = '$SPEC_URL';
+  const chunks = [];
+  https.get(url, r => {
+    r.on('data', c => chunks.push(c));
+    r.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      const spec = yaml.load(raw);
+      let filled = 0;
+      for (const ops of Object.values(spec.paths ?? {})) {
+        for (const m of ['get','post','put','patch','delete','options','head']) {
+          const op = ops?.[m];
+          if (op && !op.description && op.summary) {
+            op.description = op.summary;
+            filled++;
+          }
+        }
+      }
+      fs.writeFileSync('$PREPPED_SPEC', yaml.dump(spec));
+      console.error('[claro] filled ' + filled + ' missing operation descriptions');
+    });
+  }).on('error', e => { console.error(e); process.exit(1); });
+"
+
+echo "[claro] enhance --specId $SPEC_ID --provider $PROVIDER --format yaml --cacheResponses"
 pnpm run enhance \
   --specId "$SPEC_ID" \
-  --incomingSpecUrl "$SPEC_URL" \
+  --incomingSpecPath "$PREPPED_SPEC" \
+  --provider "$PROVIDER" \
   --format yaml \
   --cacheResponses
 

--- a/specs/apideck-mcp/README.md
+++ b/specs/apideck-mcp/README.md
@@ -1,0 +1,27 @@
+# Apideck MCP — enhanced spec
+
+This directory holds Claro's LLM-enhanced OpenAPI spec.
+
+`enhanced-openapi.yml` is consumed by `gen/node/generate.mjs` in place of
+the raw upstream spec (`speakeasy-spec.yml`) when present. The enhanced
+spec carries richer operation summaries and parameter descriptions, which
+roll up into better tool descriptions and — per Glama's TDQS scoring —
+a higher quality grade.
+
+## Generating / refreshing
+
+```bash
+# Needs OPENAI_API_KEY or ANTHROPIC_API_KEY + gh CLI access to apideck-io/claro
+./gen/run-claro.sh
+```
+
+The script clones Claro into `/tmp/apideck-claro`, runs
+`pnpm run enhance`, and copies the resulting YAML into this directory.
+
+## Why not check the raw spec in too?
+
+The raw Apideck OpenAPI (`speakeasy-spec.yml`) lives on S3 and
+`.gitignore` excludes it — it's upstream content we don't version.
+The enhanced spec is our derivative: we run Claro on it, review the
+diff, and commit the output here so CI can rebuild the generator
+without needing an LLM provider configured.


### PR DESCRIPTION
Wires [apideck-io/claro](https://github.com/apideck-io/claro) (internal LLM-based OpenAPI enhancer) into the custom generator as an optional upstream step. When an enhanced spec is checked in at `specs/apideck-mcp/enhanced-openapi.yml`, the generator reads from it instead of the raw Speakeasy spec. Falls back to the raw spec otherwise.

## What this enables

Claro rewrites terse one-line OpenAPI summaries ("List Invoices") into full LLM-authored purpose statements grounded in the spec. Feed the enhanced spec into our generator, and every tool's description inherits the richer content without touching the MCP-specific scaffolding layer from PR #44 (side effects, usage hints, connection context).

| Layer | Supplied by | Describes |
|---|---|---|
| Purpose + parameter semantics | **Claro → enhanced spec** | What the endpoint does |
| Side effect + usage + connection context + pagination | **`richDescription()` in PR #44** | How to call it correctly |

Composable — they don't overlap.

## Workflow

```
# Local (requires OPENAI_API_KEY / ANTHROPIC_API_KEY + gh CLI access to apideck-io/claro)
./gen/run-claro.sh

# Then regenerate
node gen/node/generate.mjs
```

`run-claro.sh` clones Claro into a tmp dir, `pnpm install`s, runs `enhance` against the upstream S3 spec, copies the YAML into `specs/apideck-mcp/enhanced-openapi.yml`. Review the diff, commit. CI doesn't need any LLM creds — it consumes the already-enhanced spec as static content.

## Expected quality-score impact

Glama's TDQS (Tool Definition Quality Score) graded us **C** largely because the underlying OpenAPI summaries were single terse lines. PR #44 added MCP-specific scaffolding to lift this to B on its own. Adding Claro-enhanced content under that scaffolding should comfortably push to A — and the enhancement is source-grounded (not a new rewrite) so it stays faithful to Apideck's upstream spec.

## Ops notes

- Re-run Claro whenever the upstream spec changes (can be scheduled in a separate workflow)
- Claro caches by schema hash; re-runs are cheap (LLM calls only fire for changed operations)
- Enhanced spec is tracked in git so reviewers can see description diffs on each refresh
- `.gitignore` excludes Claro's runtime working dirs (tmp, cache, overlay registry)

## Not in this PR

- Running Claro itself (needs credentials + provider choice — separate operational task)
- Auto-scheduled enhancement on spec drift — would be a follow-up workflow
- Merging PR #44's scaffolding with Claro output — PR #44 is the consumer; this PR is the producer-side plumbing
