### PR TITLE
Stamp MCP version + commit SHA on every PostHog event

### DIFF
--- a/src/mcp-server/analytics.ts
+++ b/src/mcp-server/analytics.ts
@@ -1,4 +1,32 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { ConsoleLogger } from "./console-logger.js";
+
+// Version string is stamped on every PostHog event so we can attribute
+// bugs / latency regressions to a specific deployed version. Resolves
+// package.json by walking up from this file's location — works whether
+// we're running from the src/ tree or the compiled esm/ tree.
+const MCP_VERSION = (() => {
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let i = 0; i < 6; i++) {
+      try {
+        const pkg = JSON.parse(
+          readFileSync(resolve(dir, "package.json"), "utf8"),
+        ) as { name?: string; version?: string };
+        if (pkg.name === "@apideck/mcp" && pkg.version) return pkg.version;
+      } catch {
+        /* keep walking */
+      }
+      dir = dirname(dir);
+    }
+  } catch {
+    /* fall through */
+  }
+  return "unknown";
+})();
 
 export interface AnalyticsEvent {
   distinctId: string;
@@ -34,7 +62,14 @@ export function createAnalytics(
           properties: {
             ...event.properties,
             $lib: "apideck-mcp",
+            // PostHog convention: $lib_version surfaces on every event
+            // chart automatically. We also include mcp_version as a
+            // plain property for custom filters.
+            $lib_version: MCP_VERSION,
+            mcp_version: MCP_VERSION,
             environment: process.env["VERCEL_ENV"] || "development",
+            commit_sha: process.env["VERCEL_GIT_COMMIT_SHA"],
+            deployment_url: process.env["VERCEL_URL"],
           },
           timestamp: new Date().toISOString(),
         },

--- a/test/analytics.test.mjs
+++ b/test/analytics.test.mjs
@@ -86,6 +86,15 @@ const annotations = {
   assert(ev.distinct_id === "app:consumer", "distinct_id preserved");
   assert(ev.properties.tool_name === "foo", "custom property preserved");
   assert(ev.properties.$lib === "apideck-mcp", "$lib stamped");
+  assert(
+    typeof ev.properties.$lib_version === "string"
+      && /^\d+\.\d+\.\d+/.test(ev.properties.$lib_version),
+    `$lib_version stamped (${ev.properties.$lib_version})`,
+  );
+  assert(
+    ev.properties.mcp_version === ev.properties.$lib_version,
+    "mcp_version matches $lib_version",
+  );
   assert(typeof ev.timestamp === "string", "timestamp stamped");
 }
 


### PR DESCRIPTION
## Answer to "Do we push the MCP version to posthog?"

Previously **no** — every `mcp_tool_called` event landed with `$lib=apideck-mcp` but no version info, so attributing a regression to a specific deployed build required cross-referencing timestamps against Vercel deployments.

This PR fixes that. Every event now carries:

| Property | Source | Purpose |
|---|---|---|
| `$lib_version` | `package.json` version | PostHog convention — auto-surfaces in library charts |
| `mcp_version` | same | Explicit property for custom filters (same value as `$lib_version`) |
| `commit_sha` | `VERCEL_GIT_COMMIT_SHA` | Pinpoint which commit served the call |
| `deployment_url` | `VERCEL_URL` | Pinpoint the preview/prod URL |

## Implementation

`src/mcp-server/analytics.ts` resolves the version once at module load by walking up from its own file location until it finds a `package.json` with `name: "@apideck/mcp"`. Works whether we're running from the `src/` source tree or the compiled `esm/` tree. Falls back to `"unknown"` if the walk doesn't find a match (shouldn't happen in practice).

## Use cases unblocked

- Filter dashboards by version: "error rate on 0.1.12 vs 0.1.13"
- Correlate incident reports with deployment: user says "broken at 14:00", PostHog says "all events after 14:05 are on commit `a1b2c3`"
- Retire old clients: see who's still calling from `@apideck/mcp@0.1.10` and nudge them to upgrade

## Test

`test/analytics.test.mjs` extended with two assertions — `$lib_version` is semver-shaped, `mcp_version` equals it. All 32 analytics assertions pass.
