### PR TITLE
Post-deploy smoke test (hits prod after every deploy)

### DIFF
--- a/.github/workflows/post-deploy-smoke.yaml
+++ b/.github/workflows/post-deploy-smoke.yaml
@@ -1,0 +1,55 @@
+name: Post-deploy smoke
+
+# Hits the deployed MCP endpoint after every successful Vercel
+# deployment and asserts that the dynamic meta-tools still respond.
+# Catches deploy-time regressions (config drift, env vars, handler
+# crashes) before users do.
+
+on:
+  deployment_status:
+  workflow_dispatch:
+    inputs:
+      mcp_url:
+        description: MCP endpoint URL to probe
+        type: string
+        default: https://mcp.apideck.dev/mcp
+
+permissions:
+  contents: read
+  deployments: read
+
+jobs:
+  smoke:
+    # deployment_status fires for every state (pending/in_progress/success/
+    # failure/error). Only run on success. The environment check filters out
+    # preview deploys; flip to include them if you want PR-branch coverage.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.deployment_status.state == 'success' &&
+       github.event.deployment.environment == 'Production')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve MCP URL
+        id: url
+        env:
+          DISPATCH_URL: ${{ github.event.inputs.mcp_url }}
+          DEPLOY_URL: ${{ github.event.deployment_status.target_url }}
+        run: |
+          if [ -n "$DISPATCH_URL" ]; then
+            echo "mcp_url=$DISPATCH_URL" >> "$GITHUB_OUTPUT"
+          else
+            # Vercel's deployment_status.target_url is the app URL; append /mcp
+            echo "mcp_url=${DEPLOY_URL%/}/mcp" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Smoke test
+        env:
+          MCP_URL: ${{ steps.url.outputs.mcp_url }}
+        run: node test/post-deploy.mjs

--- a/test/post-deploy.mjs
+++ b/test/post-deploy.mjs
@@ -1,0 +1,119 @@
+/**
+ * Post-deploy smoke test. Hits the deployed MCP endpoint over HTTP and
+ * asserts the plumbing is intact (no private credentials required).
+ *
+ *   MCP_URL=https://mcp.apideck.dev/mcp node test/post-deploy.mjs
+ *
+ * Runs against the default engine (custom) plus ?engine=legacy as a
+ * cross-check. Designed to run in CI from the Post-deploy Smoke
+ * workflow after every Vercel deployment.
+ */
+
+const MCP_URL = process.env.MCP_URL ?? "https://mcp.apideck.dev/mcp";
+const API_KEY = process.env.APIDECK_SMOKE_API_KEY ?? "smoke-no-key";
+const APP_ID = process.env.APIDECK_SMOKE_APP_ID ?? "smoke-no-app";
+const CONSUMER_ID = process.env.APIDECK_SMOKE_CONSUMER_ID ?? "smoke-no-consumer";
+
+let failures = 0;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`);
+    failures++;
+  } else {
+    console.log(`  PASS: ${msg}`);
+  }
+};
+
+function parseSSE(text) {
+  const line = text.split("\n").find((l) => l.startsWith("data:"));
+  if (!line) throw new Error(`No SSE data in: ${text.slice(0, 200)}`);
+  return JSON.parse(line.slice(5));
+}
+
+async function rpc(url, payload) {
+  const started = Date.now();
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      "x-apideck-api-key": API_KEY,
+      "x-apideck-app-id": APP_ID,
+      "x-apideck-consumer-id": CONSUMER_ID,
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(20_000),
+  });
+  const text = await resp.text();
+  const elapsed = Date.now() - started;
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} after ${elapsed}ms: ${text.slice(0, 200)}`);
+  return { parsed: parseSSE(text), elapsed };
+}
+
+async function check(name, url) {
+  console.log(`\n=== ${name} ===`);
+  console.log(url);
+
+  // 1. initialize
+  let res = await rpc(url, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "post-deploy-smoke", version: "1.0" },
+    },
+  });
+  assert(
+    res.parsed.result?.serverInfo?.name === "ApideckMcp",
+    `initialize serverInfo.name = ApideckMcp (got ${res.parsed.result?.serverInfo?.name})`,
+  );
+  assert(res.elapsed < 10_000, `initialize under 10s (was ${res.elapsed}ms)`);
+
+  // 2. list_tools — dynamic meta-tool, no upstream auth needed
+  res = await rpc(url, {
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: { name: "list_tools", arguments: {} },
+  });
+  const tools = JSON.parse(res.parsed.result?.content?.[0]?.text ?? "[]");
+  assert(Array.isArray(tools) && tools.length > 100, `list_tools returned ${tools.length} tools`);
+  assert(
+    tools.some((t) => t.name === "vault-connections-list"),
+    "a known tool is listed",
+  );
+  assert(res.elapsed < 10_000, `list_tools under 10s (was ${res.elapsed}ms)`);
+
+  // 3. describe_tool_input
+  res = await rpc(url, {
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: {
+      name: "describe_tool_input",
+      arguments: { tool_names: ["vault-connections-list"] },
+    },
+  });
+  const body = res.parsed.result?.content?.[0]?.text ?? "";
+  assert(body.includes("input_schema"), "describe_tool_input wraps output");
+  assert(res.elapsed < 10_000, `describe_tool_input under 10s (was ${res.elapsed}ms)`);
+}
+
+try {
+  // Default engine (custom generator)
+  await check("default engine", MCP_URL);
+
+  // Legacy engine — explicit fallback path should still respond
+  const legacyUrl = MCP_URL + (MCP_URL.includes("?") ? "&" : "?") + "engine=legacy";
+  await check("engine=legacy", legacyUrl);
+} catch (err) {
+  console.error(`\n  FAIL: ${err instanceof Error ? err.message : err}`);
+  failures++;
+}
+
+console.log(
+  `\n${failures === 0 ? "Post-deploy smoke passed" : `${failures} assertion(s) failed`}`,
+);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Catches deploy-time regressions before users do — config drift, env vars, handler crashes etc.

## How it runs

`.github/workflows/post-deploy-smoke.yaml` listens for `deployment_status` events from Vercel and fires on `state == success` + `environment == Production`. Also supports `workflow_dispatch` for manual runs against any URL.

## What it checks

`test/post-deploy.mjs` hits the MCP URL over HTTP and asserts:

| Check | Assertion |
|---|---|
| `initialize` | `serverInfo.name = ApideckMcp`, < 10s |
| `list_tools` | >100 tools, `vault-connections-list` present, < 10s |
| `describe_tool_input` | wraps output in `<input_schema>`, < 10s |

Runs against **both** the default (custom) engine and `?engine=legacy` so either side regressing is caught.

## No credentials required

Uses only the dynamic meta-tools (`list_tools`, `describe_tool_input`) which don't hit upstream Apideck — zero GitHub secrets needed. Adding real `execute_tool` smoke (which would exercise upstream auth end-to-end) is a follow-up once we decide on sandbox consumer creds in CI.

## Local dry-run

```
MCP_URL=https://mcp.apideck.dev/mcp node test/post-deploy.mjs

=== default engine ===
  PASS × 7 (p95 ~440ms)
=== engine=legacy ===
  PASS × 7 (p95 ~181ms)
Post-deploy smoke passed
```

14/14 assertions green against current prod.

## Follow-ups worth considering

- Real `execute_tool` smoke (needs a sandbox consumer with stable creds)
- Latency SLO alerts (currently just asserts <10s; a Slack ping on regression to 5s would be nicer)
- Run against preview URLs on PRs (currently scoped to Production only to avoid CI noise)
