### PR TITLE
ci(publish): trigger npm release on package code or version bumps

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,13 @@ permissions:
     branches:
       - main
     paths:
-      - .speakeasy/gen.lock
+      # Anything that affects the published tarball. The release job
+      # no-ops cleanly when there is no SDK change, and publish-npm
+      # already skips when the version is already on npm — so this
+      # trigger is idempotent.
+      - package.json
+      - src/**
+      - bin/**
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
## Summary
The Publish to npm workflow only triggered on changes to `.speakeasy/gen.lock`, so non-SDK work merged into `main` (runtime code under `src/`, README, workflows, post-deploy smoke, the LLM enhancer, etc.) never reached npm. Latest published version is **0.1.12** from 2026-04-22 even though `main` has 14+ commits since.

This widens the workflow's `paths:` filter to cover anything that affects the published tarball:

- `package.json` — version bumps (and the only thing that needs to change to ship a release)
- `src/**` — runtime code, including everything Speakeasy regenerates
- `bin/**` — the package's bin entrypoints

`.speakeasy/gen.lock` is dropped from the filter because Speakeasy SDK regen also touches `src/`, so it's already covered.

## Why this is safe
- The Speakeasy `release` job no-ops cleanly when there's no actual SDK change.
- `publish-npm` already runs a `version-check` step that skips publish when the version is already on the registry.

So pushes to `main` without a version bump produce a quick workflow run that ends in a "version already published" notice — no double-publish risk.

## Shipping the backlog
After this lands, bump `package.json` from `0.1.12` → `0.1.13` in a follow-up commit on `main`. The workflow will fire, `version-check` will see the new version, and everything currently on `main` will be published.

## Test plan
- [ ] Merge → confirm the workflow does **not** fire from this PR alone (changes only `.github/workflows/publish.yaml`, which is not in `paths:`).
- [ ] Push a no-op edit to a non-tracked path (e.g. README) → confirm publish workflow does *not* run.
- [ ] Bump `package.json` version → confirm workflow runs and publishes the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)