### PR TITLE
ci(smoke): pass Vercel Deployment Protection bypass header

### DIFF
--- a/.github/workflows/post-deploy-smoke.yaml
+++ b/.github/workflows/post-deploy-smoke.yaml
@@ -52,4 +52,8 @@ jobs:
       - name: Smoke test
         env:
           MCP_URL: ${{ steps.url.outputs.mcp_url }}
+          # Vercel returns a protected per-deployment alias URL via
+          # deployment_status.target_url. Pass the Automation bypass
+          # secret so the smoke can reach the function.
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: node test/post-deploy.mjs

--- a/test/post-deploy.mjs
+++ b/test/post-deploy.mjs
@@ -13,6 +13,11 @@ const MCP_URL = process.env.MCP_URL ?? "https://mcp.apideck.dev/mcp";
 const API_KEY = process.env.APIDECK_SMOKE_API_KEY ?? "smoke-no-key";
 const APP_ID = process.env.APIDECK_SMOKE_APP_ID ?? "smoke-no-app";
 const CONSUMER_ID = process.env.APIDECK_SMOKE_CONSUMER_ID ?? "smoke-no-consumer";
+// Vercel Deployment Protection bypass for Automation. Required when probing
+// per-deployment alias URLs (e.g. https://<project>-<hash>-<team>.vercel.app);
+// not needed for the unprotected production domain. See
+// https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
+const VERCEL_PROTECTION_BYPASS = process.env.VERCEL_AUTOMATION_BYPASS_SECRET ?? "";
 
 let failures = 0;
 const assert = (cond, msg) => {
@@ -32,15 +37,20 @@ function parseSSE(text) {
 
 async function rpc(url, payload) {
   const started = Date.now();
+  const headers = {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+    "x-apideck-api-key": API_KEY,
+    "x-apideck-app-id": APP_ID,
+    "x-apideck-consumer-id": CONSUMER_ID,
+  };
+  if (VERCEL_PROTECTION_BYPASS) {
+    headers["x-vercel-protection-bypass"] = VERCEL_PROTECTION_BYPASS;
+    headers["x-vercel-set-bypass-cookie"] = "true";
+  }
   const resp = await fetch(url, {
     method: "POST",
-    headers: {
-      "content-type": "application/json",
-      accept: "application/json, text/event-stream",
-      "x-apideck-api-key": API_KEY,
-      "x-apideck-app-id": APP_ID,
-      "x-apideck-consumer-id": CONSUMER_ID,
-    },
+    headers,
     body: JSON.stringify(payload),
     signal: AbortSignal.timeout(20_000),
   });


### PR DESCRIPTION
## Summary
The post-deploy smoke is failing on every Production deploy because Vercel's `deployment_status.target_url` is a per-deployment alias domain (`mcp-server-<hash>-apideck.vercel.app`) gated by Deployment Protection. The smoke fetch hits the auth wall and gets HTML 401 before reaching the MCP function:

> Failed run: https://github.com/apideck-libraries/mcp/actions/runs/24925597670/job/72994917405
> ```
> FAIL: HTTP 401 after 224ms: <!doctype html>...Authentication Required
> ```

## Fix
`test/post-deploy.mjs` now reads an optional `VERCEL_AUTOMATION_BYPASS_SECRET` env var. When set, every request includes:

- `x-vercel-protection-bypass: <secret>` — bypasses the protection check.
- `x-vercel-set-bypass-cookie: true` — keeps subsequent redirects working in the same session.

The workflow wires it through from a matching GitHub repo secret. When the secret is unset (e.g. running locally against the public `https://mcp.apideck.dev/mcp` production domain), the smoke behaves exactly as before — no header, no protection check needed.

## Required setup before merging
1. Vercel project → Settings → Deployment Protection → **Protection Bypass for Automation** → generate a secret.
2. Add it as a repo secret on `apideck-libraries/mcp` named `VERCEL_AUTOMATION_BYPASS_SECRET`.

## Test plan
- [ ] Confirm the secret is set on the repo and in Vercel.
- [ ] Re-run the failed smoke job (or trigger via `workflow_dispatch`) → should now reach the function.
- [ ] Local: `MCP_URL=https://mcp.apideck.dev/mcp node test/post-deploy.mjs` still works without the secret (no header sent, prod domain isn't protected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)