### PR TITLE
release: v0.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apideck/mcp",
   "mcpName": "com.apideck/mcp",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "author": "Apideck",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
Ship everything that's been on `main` since 0.1.12 was published on 2026-04-22. Under the old workflow trigger (`paths: .speakeasy/gen.lock` only), every PR merged since then was invisible to the publish flow because none of them regenerated the SDK. With #50 in, this version bump will fire the workflow via the `package.json` path.

## What this release ships
- #30 Enable all Apideck Unified APIs except SMS — tool count 229 → 330
- #35 Fix lazy-security handling in runtime (prod exec calls hung without auth)
- #41 Add code-sandbox mode: `apideck_search` + `apideck_run`
- #43 Phase 2 — URL-mode elicitation for Vault OAuth on connection failures
- #44 Enrich tool descriptions for Tool Definition Quality Score (TDQS)
- #45 Plumb Claro-enhanced OpenAPI spec into the generator
- #46 Stamp MCP version + commit SHA on every PostHog event
- #47 Lightweight LLM enhancer + disable Speakeasy cron
- #49 Phase 3 workflows + flatten tool schema (Glama D→A)

(Plus README/Docker/glama metadata changes from #36–#42.)

## Verification after merge
- [ ] Workflow run "Publish to npm" triggers on this commit landing on `main`
- [ ] `version-check` step reports `Version 0.1.13 not yet published`
- [ ] `https://www.npmjs.com/package/@apideck/mcp` shows 0.1.13 with the updated README (330 tools)
- [ ] Optional: `npx @apideck/mcp@0.1.13` boots cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)