### PR TITLE
ci(smoke): probe prod custom domain, not per-deploy alias

### DIFF
--- a/.github/workflows/post-deploy-smoke.yaml
+++ b/.github/workflows/post-deploy-smoke.yaml
@@ -40,20 +40,25 @@ jobs:
         id: url
         env:
           DISPATCH_URL: ${{ github.event.inputs.mcp_url }}
-          DEPLOY_URL: ${{ github.event.deployment_status.target_url }}
         run: |
+          # Probe the production custom domain rather than the per-deployment
+          # alias from deployment_status.target_url:
+          #   * the prod alias swap is atomic with deploy promotion — what
+          #     the smoke tests is what users hit
+          #   * no Deployment Protection bypass needed (custom domains aren't
+          #     gated)
+          #   * no DNS-propagation race for the per-deploy alias
           if [ -n "$DISPATCH_URL" ]; then
             echo "mcp_url=$DISPATCH_URL" >> "$GITHUB_OUTPUT"
           else
-            # Vercel's deployment_status.target_url is the app URL; append /mcp
-            echo "mcp_url=${DEPLOY_URL%/}/mcp" >> "$GITHUB_OUTPUT"
+            echo "mcp_url=https://mcp.apideck.dev/mcp" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Smoke test
         env:
           MCP_URL: ${{ steps.url.outputs.mcp_url }}
-          # Vercel returns a protected per-deployment alias URL via
-          # deployment_status.target_url. Pass the Automation bypass
-          # secret so the smoke can reach the function.
+          # Bypass kept available for `workflow_dispatch` runs that point at
+          # a per-deployment alias (preview / staging URL). On the default
+          # Production path the prod alias is unprotected, so this is a no-op.
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: node test/post-deploy.mjs


### PR DESCRIPTION
The post-deploy smoke (PR #51) currently points at the per-deployment alias from \`deployment_status.target_url\` (e.g. \`mcp-server-fg44lmi25-apideck.vercel.app\`). That URL:

- sits behind Vercel Deployment Protection (needs the bypass header we just set up)
- has its own DNS propagation lag — smokes can race the alias coming online and fail with \`fetch failed\` (which is exactly what just happened on the post-#51 run)
- isn't what users actually hit

The production custom domain \`mcp.apideck.dev\` is aliased atomically with deploy promotion. At the moment \`deployment_status\` fires for Production, the alias has already swapped. Smoking the user-facing URL is more correct *and* removes the race.

The bypass secret stays wired for \`workflow_dispatch\` runs that explicitly point at a preview/per-deploy URL — useful for ad-hoc probes of a not-yet-promoted deployment.

## Test plan
- [x] Local: \`curl https://mcp.apideck.dev/mcp\` → 200 (no auth, no bypass)
- [ ] Merge → next prod deploy → smoke runs against \`mcp.apideck.dev\` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)