### PR TITLE
Phase 3 #3: receive-customer-payment (AR mirror of pay-bill)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
           node test/gen-elicitation.test.mjs
           node test/gen-workflows.test.mjs
           node test/gen-workflow-pay-bill.test.mjs
+          node test/gen-workflow-receive-payment.test.mjs
 
   deploy:
     needs: build-and-test

--- a/src/gen/workflows/index.ts
+++ b/src/gen/workflows/index.ts
@@ -10,9 +10,11 @@
 
 import { apideckMonthEndCloseCheck } from "./monthEndClose.js";
 import { apideckPayBill } from "./payBill.js";
+import { apideckReceiveCustomerPayment } from "./receivePayment.js";
 import type { WorkflowTool } from "./helpers.js";
 
 export const workflowTools: WorkflowTool[] = [
   apideckMonthEndCloseCheck,
   apideckPayBill,
+  apideckReceiveCustomerPayment,
 ];

--- a/src/gen/workflows/receivePayment.ts
+++ b/src/gen/workflows/receivePayment.ts
@@ -1,0 +1,182 @@
+/**
+ * `apideck-receive-customer-payment` — fetches an invoice, then writes
+ * an AR payment that allocates back to it so the connector marks the
+ * invoice (partially) settled in one MCP call. AR mirror of
+ * `apideck-pay-bill`.
+ */
+
+import * as z from "zod";
+import {
+  extractServiceContext,
+  pickData,
+  runStep,
+  workflowJsonResult,
+  type WorkflowTool,
+} from "./helpers.js";
+
+// `allocations[].type = "invoice"` is the load-bearing field that tells
+// the connector which invoice this payment settles.
+const ALLOCATION_TYPE_INVOICE = "invoice";
+
+const args = {
+  invoice_id: z
+    .string()
+    .min(1)
+    .describe("ID of the invoice being paid (returned by `accounting-invoices-list`)."),
+  account_id: z
+    .string()
+    .min(1)
+    .describe(
+      "ID of the deposit account that received the payment (typically a bank or undeposited-funds account from `accounting-ledger-accounts-list`).",
+    ),
+  amount: z
+    .number()
+    .positive()
+    .optional()
+    .describe(
+      "Amount received in the invoice's currency. Defaults to the invoice's outstanding balance. Pass a smaller value for a partial payment.",
+    ),
+  transaction_date: z
+    .string()
+    .optional()
+    .describe(
+      "Payment date (YYYY-MM-DD). Defaults to today. Connectors sometimes reject future dates.",
+    ),
+  payment_method: z
+    .string()
+    .optional()
+    .describe(
+      "Payment method label. QuickBooks requires capitalized values: \"Check\", \"CreditCard\", \"Cash\". Other connectors accept lower-case \"check\" / \"credit_card\" / \"ach\" / \"wire\". When omitted, QuickBooks rejects the payment with a parse error — pass an explicit value for QB.",
+    ),
+  reference: z
+    .string()
+    .optional()
+    .describe("Memo / external reference shown on the payment record."),
+  "x-apideck-service-id": z
+    .string()
+    .optional()
+    .describe(
+      "Target accounting service when the consumer has multiple connections (e.g. \"xero\", \"quickbooks\").",
+    ),
+};
+
+type ReceivePaymentArgs = {
+  invoice_id: string;
+  account_id: string;
+  amount?: number;
+  transaction_date?: string;
+  payment_method?: string;
+  reference?: string;
+};
+
+export const apideckReceiveCustomerPayment: WorkflowTool = {
+  name: "apideck-receive-customer-payment",
+  description: [
+    "Record a customer payment against an invoice in one shot.",
+    "",
+    "Looks up the invoice, then creates an AR payment allocated against it so the connected accounting service marks the invoice (partially) paid. AR mirror of `apideck-pay-bill` (which is for vendor bills / AP). Saves the agent from confusing AR customer-payments with AP bill-payments — different unified endpoints, different connector semantics.",
+    "",
+    "**Mutating, not idempotent.** Each call creates a new payment record on the connector. Calling twice with the same arguments produces two payments. Confirm the user intended to record the payment before invoking.",
+    "",
+    "Use when the user wants to record a customer payment against a known invoice. For paying a vendor bill use `apideck-pay-bill` instead. For raw payment creation (unallocated transfers, prepayments) call `accounting-payments-create` directly.",
+    "",
+    "Requires an active `accounting` connection on the consumer. If the consumer has multiple accounting services connected, pass `x-apideck-service-id` (e.g. \"xero\", \"quickbooks\") to target one. Consumer auth is resolved server-side — don't pass API keys in arguments.",
+  ].join("\n"),
+  scopes: ["write"],
+  annotations: {
+    title: "Receive customer payment",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
+  args,
+  async tool(client, a, ctx) {
+    const flat = a as ReceivePaymentArgs;
+    const { serviceId, common } = extractServiceContext(a);
+    const transactionDate = flat.transaction_date
+      ?? new Date().toISOString().slice(0, 10);
+
+    const invoiceStep = await runStep<Record<string, unknown>>(
+      client,
+      "accounting-invoices-get",
+      { ...common, id: flat.invoice_id },
+      ctx,
+      (body) => pickData(body) as Record<string, unknown>,
+    );
+    if (!invoiceStep.ok) {
+      // Distinguish "invoice doesn't exist / connector down" from a generic
+      // upstream error so the LLM doesn't blindly retry the workflow.
+      return workflowJsonResult({
+        invoice_id: flat.invoice_id,
+        error: invoiceStep.unsupported ? invoiceStep.reason : invoiceStep.error,
+        failingStep: "accounting-invoices-get",
+        upstream: invoiceStep.upstream,
+      }, true);
+    }
+
+    const invoice = invoiceStep.data;
+    // Connectors disagree on the total/balance field name. QuickBooks
+    // returns `total`; Apideck's unified spec prefers `total_amount`.
+    // Prefer `balance` (outstanding) over the gross total so a partial
+    // payment doesn't accidentally over-pay an already-partial invoice.
+    const invoiceTotal = Number(
+      invoice["balance"] ?? invoice["total_amount"] ?? invoice["total"] ?? 0,
+    );
+    const currency = (invoice["currency"] as string | undefined) ?? "USD";
+    const customer = invoice["customer"] as { id?: string } | undefined;
+    const amount = flat.amount ?? invoiceTotal;
+
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return workflowJsonResult({
+        invoice_id: flat.invoice_id,
+        error: `Invoice has no positive outstanding balance (got ${invoice["balance"] ?? invoice["total_amount"] ?? invoice["total"]}). Pass an explicit \`amount\` to override.`,
+        failingStep: "validate-amount",
+      }, true);
+    }
+
+    const paymentBody: Record<string, unknown> = {
+      total_amount: amount,
+      currency,
+      transaction_date: transactionDate,
+      account: { id: flat.account_id },
+      allocations: [{ id: flat.invoice_id, type: ALLOCATION_TYPE_INVOICE, amount }],
+      ...(customer?.id ? { customer: { id: customer.id } } : {}),
+      ...(flat.payment_method ? { payment_method: flat.payment_method } : {}),
+      ...(flat.reference ? { reference: flat.reference } : {}),
+    };
+
+    // AR endpoint: customer payments. For vendor bills use
+    // accounting-bill-payments-create (apideck-pay-bill).
+    const paymentStep = await runStep<Record<string, unknown>>(
+      client,
+      "accounting-payments-create",
+      { ...common, body: paymentBody },
+      ctx,
+      (body) => pickData(body) as Record<string, unknown>,
+    );
+    if (!paymentStep.ok) {
+      return workflowJsonResult({
+        invoice_id: flat.invoice_id,
+        amount,
+        currency,
+        error: paymentStep.unsupported ? paymentStep.reason : paymentStep.error,
+        failingStep: "accounting-payments-create",
+        upstream: paymentStep.upstream,
+      }, true);
+    }
+
+    const payment = paymentStep.data;
+    return workflowJsonResult({
+      invoice_id: flat.invoice_id,
+      payment_id: payment["id"] ?? null,
+      amount,
+      currency,
+      transaction_date: transactionDate,
+      invoice_total: invoiceTotal,
+      // Compare in cents to avoid float drift on decimal currencies.
+      partial: Math.round(amount * 100) < Math.round(invoiceTotal * 100),
+      service_id: serviceId ?? null,
+    });
+  },
+};

--- a/test/gen-workflow-receive-payment.test.mjs
+++ b/test/gen-workflow-receive-payment.test.mjs
@@ -1,0 +1,338 @@
+/**
+ * Tests for `apideck-receive-customer-payment`. AR mirror of pay-bill.
+ * Covers: registration + write scope, happy-path full payment,
+ * missing invoice, partial payment, zero-balance guard, payment-create
+ * failure, McpError elicitation pass-through.
+ */
+
+import { createGeneratedMCPServer } from "../esm/src/gen/create-server.js";
+import { workflowTools } from "../esm/src/gen/workflows/index.js";
+
+let failures = 0;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`);
+    failures++;
+  } else {
+    console.log(`  PASS: ${msg}`);
+  }
+};
+
+const logger = {
+  level: "info",
+  debug() {},
+  info() {},
+  warning() {},
+  error() {},
+};
+
+const fakeSDK = () => ({
+  _options: {
+    appId: "app",
+    consumerId: "consumer",
+    security: async () => ({ apiKey: "sk_test_recv" }),
+  },
+});
+
+function stubFetch(routes) {
+  const calls = [];
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (input, opts = {}) => {
+    const url = input instanceof Request ? input.url : String(input);
+    const body = opts.body && typeof opts.body === "string"
+      ? (() => { try { return JSON.parse(opts.body); } catch { return opts.body; } })()
+      : undefined;
+    calls.push({
+      url,
+      method: opts.method,
+      headers: Object.fromEntries(opts.headers?.entries?.() ?? []),
+      body,
+    });
+    for (const [pattern, route] of Object.entries(routes)) {
+      if (url.includes(pattern)) {
+        const status = route.__status ?? 200;
+        return new Response(JSON.stringify(route), {
+          status,
+          headers: { "content-type": "application/json" },
+        });
+      }
+    }
+    return new Response("not stubbed", { status: 500 });
+  };
+  return { calls, restore: () => (globalThis.fetch = orig) };
+}
+
+const booted = createGeneratedMCPServer({
+  logger,
+  dynamic: true,
+  getSDK: fakeSDK,
+});
+const exec = booted.server._registeredTools.execute_tool;
+
+// ---------------------------------------------------------------------------
+// 1. Registered with write scope, mirrors pay-bill annotations
+// ---------------------------------------------------------------------------
+console.log("Test: apideck-receive-customer-payment registered with write scope");
+{
+  assert(
+    booted.tools.some((t) => t.name === "apideck-receive-customer-payment"),
+    "tool registered in booted server",
+  );
+  const def = workflowTools.find((t) => t.name === "apideck-receive-customer-payment");
+  assert(def, "workflow definition exported");
+  assert(def.scopes?.includes("write"), "scope includes write");
+  assert(def.annotations?.readOnlyHint === false, "not read-only");
+  assert(def.annotations?.idempotentHint === false, "not idempotent");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Happy path: full payment of an invoice routes to AR endpoint
+// ---------------------------------------------------------------------------
+console.log("Test: receives full invoice amount and links allocation type=invoice");
+{
+  const stub = stubFetch({
+    "/accounting/invoices/inv-42": {
+      data: {
+        id: "inv-42",
+        total_amount: 250.5,
+        currency: "EUR",
+        customer: { id: "cust-9", display_name: "ACME Co" },
+      },
+    },
+    "/accounting/payments": {
+      data: { id: "pay-77", total_amount: 250.5 },
+    },
+  });
+
+  const res = await exec.handler(
+    {
+      name: "apideck-receive-customer-payment",
+      arguments: {
+        invoice_id: "inv-42",
+        account_id: "acc-bank",
+        transaction_date: "2026-04-26",
+        reference: "Q2 receivable",
+        "x-apideck-service-id": "xero",
+      },
+    },
+    { signal: new AbortController().signal },
+  );
+  stub.restore();
+
+  assert(res.isError !== true, "not an error");
+  const payload = JSON.parse(res.content[0].text);
+  assert(payload.invoice_id === "inv-42", "invoice_id echoed");
+  assert(payload.payment_id === "pay-77", "payment_id from upstream");
+  assert(payload.amount === 250.5, "amount defaulted to invoice total");
+  assert(payload.currency === "EUR", "currency from invoice");
+  assert(payload.partial === false, "full payment → partial:false");
+  assert(payload.service_id === "xero", "service_id echoed");
+
+  assert(stub.calls.length === 2, `2 upstream calls (got ${stub.calls.length})`);
+  const [invCall, payCall] = stub.calls;
+  assert(invCall.method === "GET" && invCall.url.includes("/invoices/inv-42"), "GET invoice");
+  // AR endpoint — `/payments`, NOT `/bill-payments`
+  assert(
+    payCall.method === "POST" && payCall.url.includes("/payments") && !payCall.url.includes("/bill-payments"),
+    `POST to AR /payments (got ${payCall.url})`,
+  );
+  assert(payCall.headers["x-apideck-service-id"] === "xero", "service_id forwarded to payment call");
+  assert(payCall.body?.total_amount === 250.5, "payment total_amount set");
+  assert(payCall.body?.currency === "EUR", "payment currency set");
+  assert(payCall.body?.account?.id === "acc-bank", "payment account.id set");
+  assert(payCall.body?.transaction_date === "2026-04-26", "transaction_date set");
+  assert(payCall.body?.reference === "Q2 receivable", "reference forwarded");
+  assert(Array.isArray(payCall.body?.allocations) && payCall.body.allocations.length === 1, "1 allocation");
+  assert(payCall.body.allocations[0].id === "inv-42", "allocation points at invoice");
+  assert(payCall.body.allocations[0].type === "invoice", "allocation type=invoice");
+  assert(payCall.body.allocations[0].amount === 250.5, "allocation amount = total");
+  assert(payCall.body?.customer?.id === "cust-9", "customer carried from invoice");
+  assert(!payCall.body?.supplier, "no supplier on AR payment");
+}
+
+// ---------------------------------------------------------------------------
+// 3. Missing invoice → fail-fast on invoices-get, no payment created
+// ---------------------------------------------------------------------------
+console.log("Test: missing invoice aborts, no payment posted");
+{
+  const stub = stubFetch({
+    "/accounting/invoices/inv-missing": {
+      __status: 404,
+      status_code: 404,
+      type_name: "EntityNotFoundError",
+      message: "Invoice not found",
+    },
+  });
+
+  const res = await exec.handler(
+    {
+      name: "apideck-receive-customer-payment",
+      arguments: { invoice_id: "inv-missing", account_id: "acc-bank" },
+    },
+    { signal: new AbortController().signal },
+  );
+  stub.restore();
+
+  assert(res.isError === true, "isError flagged");
+  const payload = JSON.parse(res.content[0].text);
+  assert(payload.failingStep === "accounting-invoices-get", "failingStep names invoice lookup");
+  assert(payload.invoice_id === "inv-missing", "invoice_id echoed in error");
+  assert(stub.calls.length === 1, "no payment POST after lookup failed");
+}
+
+// ---------------------------------------------------------------------------
+// 4. Connector-quirk: invoice has `total` not `total_amount` (QB shape)
+// ---------------------------------------------------------------------------
+console.log("Test: falls back to `balance` then `total` when total_amount absent");
+{
+  const stub = stubFetch({
+    "/accounting/invoices/inv-qb": {
+      data: {
+        id: "inv-qb",
+        // NO total_amount; QB-style fields
+        balance: 50,
+        total: 100,
+        currency: "USD",
+        customer: { id: "c1" },
+      },
+    },
+    "/accounting/payments": { data: { id: "pay-q1" } },
+  });
+
+  const res = await exec.handler(
+    { name: "apideck-receive-customer-payment", arguments: { invoice_id: "inv-qb", account_id: "a1" } },
+    { signal: new AbortController().signal },
+  );
+  stub.restore();
+
+  const payload = JSON.parse(res.content[0].text);
+  assert(payload.amount === 50, `amount = balance (50), got ${payload.amount}`);
+  assert(payload.invoice_total === 50, "invoice_total reflects balance");
+}
+
+// ---------------------------------------------------------------------------
+// 5. Partial payment: explicit amount < outstanding → partial:true
+// ---------------------------------------------------------------------------
+console.log("Test: explicit amount < invoice total → partial:true");
+{
+  const stub = stubFetch({
+    "/accounting/invoices/inv-1": {
+      data: { id: "inv-1", total_amount: 1000, currency: "USD", customer: { id: "c1" } },
+    },
+    "/accounting/payments": { data: { id: "pay-p1" } },
+  });
+
+  const res = await exec.handler(
+    {
+      name: "apideck-receive-customer-payment",
+      arguments: { invoice_id: "inv-1", account_id: "acc-1", amount: 400 },
+    },
+    { signal: new AbortController().signal },
+  );
+  stub.restore();
+
+  const payload = JSON.parse(res.content[0].text);
+  assert(payload.partial === true, "partial:true on under-payment");
+  assert(payload.amount === 400, "amount honoured");
+  const payCall = stub.calls.find((c) => c.url.includes("/payments"));
+  assert(payCall?.body?.allocations[0].amount === 400, "allocation amount = explicit amount");
+}
+
+// ---------------------------------------------------------------------------
+// 6. Zero-balance invoice without override → validate-amount error
+// ---------------------------------------------------------------------------
+console.log("Test: zero-balance invoice without explicit amount errors out");
+{
+  const stub = stubFetch({
+    "/accounting/invoices/inv-zero": {
+      data: { id: "inv-zero", balance: 0, total: 100, currency: "USD", customer: { id: "c1" } },
+    },
+  });
+
+  const res = await exec.handler(
+    { name: "apideck-receive-customer-payment", arguments: { invoice_id: "inv-zero", account_id: "a1" } },
+    { signal: new AbortController().signal },
+  );
+  stub.restore();
+
+  assert(res.isError === true, "isError flagged");
+  const payload = JSON.parse(res.content[0].text);
+  assert(payload.failingStep === "validate-amount", "failingStep is validate-amount");
+  assert(stub.calls.length === 1, "no payment POST attempted");
+}
+
+// ---------------------------------------------------------------------------
+// 7. Payment-create failure surfaces as failingStep
+// ---------------------------------------------------------------------------
+console.log("Test: payment-create failure carries failingStep + upstream");
+{
+  const stub = stubFetch({
+    "/accounting/invoices/inv-99": {
+      data: { id: "inv-99", total_amount: 100, currency: "USD", customer: { id: "c2" } },
+    },
+    "/accounting/payments": {
+      __status: 422,
+      status_code: 422,
+      type_name: "ValidationError",
+      message: "account.id is invalid",
+    },
+  });
+
+  const res = await exec.handler(
+    {
+      name: "apideck-receive-customer-payment",
+      arguments: { invoice_id: "inv-99", account_id: "acc-bad" },
+    },
+    { signal: new AbortController().signal },
+  );
+  stub.restore();
+
+  assert(res.isError === true, "isError flagged");
+  const payload = JSON.parse(res.content[0].text);
+  assert(payload.failingStep === "accounting-payments-create", "failingStep on payment");
+  assert(
+    typeof payload.error === "string" && payload.error.includes("account.id"),
+    "upstream error text bubbles up",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 8. UrlElicitation propagates (not swallowed by runStep)
+// ---------------------------------------------------------------------------
+console.log("Test: McpError elicitation thrown, not wrapped");
+{
+  const stub = stubFetch({
+    "/accounting/invoices/inv-X": {
+      __status: 401,
+      message: "Connection is missing — please re-authorise the connection.",
+      detail: { context: { connector: "xero", unified_api: "accounting" } },
+    },
+    "/vault/sessions": { data: { session_uri: "https://vault.apideck.com/session/test-jwt" } },
+  });
+
+  let thrown;
+  try {
+    await exec.handler(
+      {
+        name: "apideck-receive-customer-payment",
+        arguments: { invoice_id: "inv-X", account_id: "acc-1" },
+      },
+      { signal: new AbortController().signal },
+    );
+  } catch (err) {
+    thrown = err;
+  }
+  stub.restore();
+
+  assert(thrown?.name === "McpError", `McpError thrown, got ${thrown?.name}`);
+  const url = thrown?.data?.elicitations?.[0]?.url;
+  assert(
+    typeof url === "string" && url.includes("vault.apideck.com/session"),
+    "consent URL preserved through workflow",
+  );
+}
+
+console.log(
+  `\n${failures === 0 ? "All receive-payment tests passed" : `${failures} test(s) failed`}`,
+);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Stacked on PR #54 — when #54 merges, rebase this on main.

Third Phase 3 workflow. Records a customer payment against an invoice in one MCP call — AR mirror of pay-bill. Fetches the invoice, reads outstanding balance, posts an AR payment with \`allocations[].type=\"invoice\"\`.

## Differences from pay-bill (only the load-bearing ones)

| | pay-bill (AP) | receive-payment (AR) |
|---|---|---|
| Lookup | \`accounting-bills-get\` | \`accounting-invoices-get\` |
| Create | \`accounting-bill-payments-create\` | \`accounting-payments-create\` |
| Allocation type | \`bill\` | \`invoice\` |
| Counterparty | \`supplier\` | \`customer\` |

Everything else (balance/total fallback, integer-cents partial, McpError pass-through, extractServiceContext, response shape) is inherited unchanged from helpers.ts.

## Live verification (Moneybird sandbox)
- ✅ Invoice fetched with balance €14,539.36
- ✅ Body built with \`allocations[].type=invoice\` + \`customer.id\` (not supplier)
- ✅ Routed to \`/accounting/payments\` (AR), not \`/accounting/bill-payments\` (AP)
- ✅ Upstream 404 surfaced verbatim through error envelope
- 🚫 Happy-path POST blocked: Moneybird models customer payments as \`financial_mutations\` rather than \`payments\` (connector coverage gap, not a workflow bug). QuickBooks sandbox subscription still expired.

## Test plan
- [x] 44/44 stub assertions: registration, full payment, missing invoice, balance fallback, partial, zero-balance guard, payment-create failure, McpError elicitation pass-through
- [x] Existing 8 unit suites still green
- [x] \`npm run lint\` clean
- [x] Added to CI

Phase 3: 3 / 5 complete (month-end-close, pay-bill, receive-customer-payment). Two left: \`apideck-onboard-employee\`, \`apideck-process-vendor-invoice\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)