### PR TITLE
ci(smoke): real upstream execute_tool check after meta-tools

### DIFF
--- a/.github/workflows/post-deploy-smoke.yaml
+++ b/.github/workflows/post-deploy-smoke.yaml
@@ -61,4 +61,11 @@ jobs:
           # a per-deployment alias (preview / staging URL). On the default
           # Production path the prod alias is unprotected, so this is a no-op.
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          # Real upstream creds for the execute_tool stage. When unset, the
+          # smoke skips the live upstream check and runs meta-tools only.
+          # Suggested consumer: `test-consumer-id` (sandbox with QuickBooks /
+          # Moneybird connections pre-authorized).
+          APIDECK_SMOKE_API_KEY: ${{ secrets.APIDECK_SMOKE_API_KEY }}
+          APIDECK_SMOKE_APP_ID: ${{ secrets.APIDECK_SMOKE_APP_ID }}
+          APIDECK_SMOKE_CONSUMER_ID: ${{ secrets.APIDECK_SMOKE_CONSUMER_ID }}
         run: node test/post-deploy.mjs

--- a/test/post-deploy.mjs
+++ b/test/post-deploy.mjs
@@ -109,6 +109,39 @@ async function check(name, url) {
   const body = res.parsed.result?.content?.[0]?.text ?? "";
   assert(body.includes("input_schema"), "describe_tool_input wraps output");
   assert(res.elapsed < 10_000, `describe_tool_input under 10s (was ${res.elapsed}ms)`);
+
+  // 4. execute_tool against a real upstream — only when credentials are
+  // wired in CI secrets. We use `vault-connections-list` because it hits
+  // Apideck Vault itself (not a downstream connector), so it isolates the
+  // Apideck request path without depending on any specific SaaS being
+  // online + connected. A 200 here proves: server resolves bound creds,
+  // forwards the Bearer token, dispatches to api.apideck.com, and parses
+  // the response — i.e. the entire production happy path.
+  if (API_KEY === "smoke-no-key") {
+    console.log("  SKIP: APIDECK_SMOKE_API_KEY not set — skipping live upstream check");
+    return;
+  }
+  res = await rpc(url, {
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: {
+      name: "execute_tool",
+      arguments: { name: "vault-connections-list", arguments: {} },
+    },
+  });
+  const callResult = res.parsed.result;
+  const callText = callResult?.content?.[0]?.text ?? "";
+  assert(callResult?.isError !== true, `execute_tool succeeded (got isError=${callResult?.isError}, body=${callText.slice(0, 120)})`);
+  let callBody;
+  try {
+    callBody = JSON.parse(callText);
+  } catch {
+    assert(false, `execute_tool body is JSON (got: ${callText.slice(0, 120)})`);
+    return;
+  }
+  assert(Array.isArray(callBody.data), "vault-connections-list returns data[]");
+  assert(res.elapsed < 15_000, `execute_tool under 15s (was ${res.elapsed}ms)`);
 }
 
 try {


### PR DESCRIPTION
Phase 6 #1 — extends the post-deploy smoke beyond meta-tools to a real \`execute_tool\` call against production.

## What was uncovered

The post-deploy smoke (added in #48) only exercised the dynamic meta-tools — \`initialize\` / \`list_tools\` / \`describe_tool_input\`. Those check the handshake and the discovery surface but never touch the production code path that actually calls Apideck:

- credential resolution (lazy security resolver from bound creds)
- Bearer-token forwarding to api.apideck.com
- dispatch + SSE response parsing
- error-envelope normalization

A regression in any of those would have landed silently. The lazy-security bug we fixed in [#35](https://github.com/apideck-libraries/mcp/pull/35) would not have been caught by this smoke.

## What this adds

A 4th step that calls \`execute_tool\` with \`vault-connections-list\` (Apideck Vault itself, not a downstream connector — isolates the Apideck request path without depending on QuickBooks/Xero/etc. being online and authorized; read-only; deterministic shape).

\`\`\`
=== default engine ===
  PASS: initialize serverInfo.name = ApideckMcp (got ApideckMcp)
  PASS: list_tools returned 335 tools
  PASS: a known tool is listed
  PASS: describe_tool_input wraps output
  PASS: execute_tool succeeded (got isError=false, body={\"data\":[...]})
  PASS: vault-connections-list returns data[]
  PASS: execute_tool under 15s (was 1279ms)
\`\`\`

Skips when \`APIDECK_SMOKE_API_KEY\` is unset, so contributors running the smoke locally without creds still get the meta-tool checks.

## What needs to happen on the GitHub side

Three new repo secrets need to be set for CI to exercise the live path:

| Secret | Suggested value |
|---|---|
| \`APIDECK_SMOKE_API_KEY\` | An Apideck sandbox API key (read-only is fine) |
| \`APIDECK_SMOKE_APP_ID\` | The corresponding app id |
| \`APIDECK_SMOKE_CONSUMER_ID\` | \`test-consumer-id\` — the sandbox consumer that already has QuickBooks / Moneybird authorized |

When unset the smoke prints \`SKIP: APIDECK_SMOKE_API_KEY not set\` and continues with the meta-tool checks only.

## Test plan
- [x] Smoke runs locally without creds → 7/7 meta-tool PASS, upstream SKIP
- [x] Smoke runs locally with creds against \`mcp.apideck.dev\` → 10/10 PASS, both engines (default custom 1.3s, legacy 0.6s upstream roundtrip)
- [ ] After secret is added, next prod deploy triggers the smoke and exercises the live path

🤖 Generated with [Claude Code](https://claude.com/claude-code)