### PR TITLE
ci(registry): skip publish when version already in MCP Registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yaml
+++ b/.github/workflows/publish-mcp-registry.yaml
@@ -64,15 +64,36 @@ jobs:
           sudo mv mcp-publisher /usr/local/bin/
           mcp-publisher --help
 
+      - name: Skip if already in registry
+        id: registry-check
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          # The npm publish workflow is idempotent — it skips when a version
+          # is already on npm. This `workflow_run` trigger fires regardless
+          # of whether anything was actually published, so guard the
+          # registry publish the same way to avoid 400 "duplicate version"
+          # failures on no-op runs (post-merge to main without a bump).
+          if curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers/com.apideck%2Fmcp/versions" \
+              | jq -e --arg v "$VERSION" '.servers[].server.version == $v' > /dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Version $VERSION already in MCP Registry — skipping publish"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION not yet in registry"
+          fi
+
       - name: Authenticate with MCP Registry (DNS)
+        if: steps.registry-check.outputs.skip == 'false'
         run: mcp-publisher login dns --domain=apideck.com --private-key="$MCP_REGISTRY_PRIVATE_KEY"
         env:
           MCP_REGISTRY_PRIVATE_KEY: ${{ secrets.MCP_REGISTRY_PRIVATE_KEY }}
 
       - name: Publish
+        if: steps.registry-check.outputs.skip == 'false'
         run: mcp-publisher publish
 
       - name: Verify in registry
+        if: steps.registry-check.outputs.skip == 'false'
         run: |
           sleep 5
           curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=com.apideck/mcp" | jq .


### PR DESCRIPTION
Fixes the MCP Registry publish failure from [run 24953625602](https://github.com/apideck-libraries/mcp/actions/runs/24953625602).

## Root cause

The Publish to MCP Registry workflow runs via \`workflow_run\` after Publish to npm completes. The npm publish workflow is idempotent — it skips when the version is already on npm and reports success — so the registry workflow fires even on no-op runs (e.g. merge to main without a version bump). The mcp-publisher CLI then errors with:

\`\`\`
publish failed: server returned status 400:
  {\"errors\":[{\"message\":\"invalid version: cannot publish duplicate version\"}]}
\`\`\`

…which marks the workflow run failed and emails everyone.

## Fix

Add a \`Skip if already in registry\` step that hits \`registry.modelcontextprotocol.io/v0/servers/com.apideck%2Fmcp/versions\` and skips the login + publish + verify steps when the current \`package.json\` version is already there. Mirrors the version-check guard that's already in \`publish.yaml\`.

## Test plan
- [x] curl the registry API locally — confirms \`0.1.13\` is already there, jq guard correctly returns true
- [ ] After merge, the next no-op push to main triggers npm publish (skipped) → registry publish (now also skipped) — green run instead of red
- [ ] When a real version bump lands, both publish steps run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)